### PR TITLE
Clear bad state during recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ defmodule ShowcaseAppWeb.CounterLive do
           # socket with previously stashed assigns is recovered
           recovered_socket
 
-        _ ->
-          # could not recover assigns, proceed with standard setup
+        {_, socket} ->
+          # could not recover assigns, proceed with standard setup using returned socket
           # ...
     end
     |> then(&{:ok, &1})

--- a/docs/example.md
+++ b/docs/example.md
@@ -136,6 +136,6 @@ The `mount/3` lifecycle hook is where LiveStash's recovery mechanism kicks in. W
 
 If LiveStash finds a previously saved state (like an ongoing game), it returns `{:recovered, recovered_socket}` and seamlessly resumes the game right where the user left off. If no state is found (e.g., it's a brand new visit), it falls back to starting a fresh game with `start_new_game(socket)`.
 
-> #### Warning {: .warning}
+> #### Note {: .note}
 >
 > In case of an error you must use the returned socket for the invalid state to be cleared.

--- a/docs/example.md
+++ b/docs/example.md
@@ -125,11 +125,8 @@ Crucially, after updating the socket assigns, we pipe it into `stash_assigns([:b
       {:recovered, recovered_socket} ->
         recovered_socket
 
-      {:error, socket} -> # using the recovered socket in error case to clear the invalid state
-        socket
-        |> start_new_game()
-
-      _ -> start_new_game(socket)
+      {_, socket} ->
+        start_new_game(socket)
     end
     |> then(&{:ok, &1})
   end

--- a/docs/example.md
+++ b/docs/example.md
@@ -124,6 +124,11 @@ Crucially, after updating the socket assigns, we pipe it into `stash_assigns([:b
     |> case do
       {:recovered, recovered_socket} ->
         recovered_socket
+
+      {:error, socket} -> # using the recovered socket in error case to clear the invalid state
+        socket
+        |> start_new_game()
+
       _ -> start_new_game(socket)
     end
     |> then(&{:ok, &1})
@@ -133,3 +138,7 @@ Crucially, after updating the socket assigns, we pipe it into `stash_assigns([:b
 The `mount/3` lifecycle hook is where LiveStash's recovery mechanism kicks in. When a user connects to the LiveView (or reconnects after a network drop), we immediately call `recover_state/1`.
 
 If LiveStash finds a previously saved state (like an ongoing game), it returns `{:recovered, recovered_socket}` and seamlessly resumes the game right where the user left off. If no state is found (e.g., it's a brand new visit), it falls back to starting a fresh game with `start_new_game(socket)`.
+
+> #### Warning {: .warning}
+>
+> In case of an error you must use the returned socket for the invalid state to be cleared.

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -37,8 +37,8 @@ defmodule ShowcaseAppWeb.CounterLive do
           # socket with previously stashed assigns is recovered
           recovered_socket
 
-        _ ->
-          # could not recover assigns, proceed with standard setup
+        {_, socket} ->
+          # could not recover assigns, proceed with standard setup using returned socket
           # ...
     end
     |> then(&{:ok, &1})

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
@@ -9,12 +9,9 @@ defmodule ShowcaseAppWeb.LiveStashClientCounterLive do
         {:recovered, recovered_socket} ->
           recovered_socket
 
-        {:error, socket} ->
+        {_, socket} ->
           socket
           |> assign(count: 0)
-
-        _ ->
-          assign(socket, count: 0)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.LiveStashClientCounterLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 5 * 60 * 1000
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 5000
 
   def mount(_params, _session, socket) do
     socket
@@ -8,6 +8,10 @@ defmodule ShowcaseAppWeb.LiveStashClientCounterLive do
     |> case do
         {:recovered, recovered_socket} ->
           recovered_socket
+
+        {:error, socket} ->
+          socket
+          |> assign(count: 0)
 
         _ ->
           assign(socket, count: 0)

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
@@ -10,8 +10,7 @@ defmodule ShowcaseAppWeb.LiveStashClientCounterLive do
           recovered_socket
 
         {_, socket} ->
-          socket
-          |> assign(count: 0)
+          assign(socket, count: 0)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_client_counter_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.LiveStashClientCounterLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 5000
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt
 
   def mount(_params, _session, socket) do
     socket

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_server_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_server_counter_live.ex
@@ -9,8 +9,9 @@ defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
         {:recovered, recovered_socket} ->
           recovered_socket
 
-        _ ->
-          assign(socket, count: 0)
+        {_, socket} ->
+          socket
+          |> assign(count: 0)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_server_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_server_counter_live.ex
@@ -10,8 +10,7 @@ defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
           recovered_socket
 
         {_, socket} ->
-          socket
-          |> assign(count: 0)
+          assign(socket, count: 0)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_client_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_client_counter_live.ex
@@ -9,8 +9,8 @@ defmodule ShowcaseAppWeb.E2eTest.LiveStashClientCounterLive do
         {:recovered, recovered_socket} ->
           recovered_socket
 
-        _ ->
-          assign(socket, count: 0)
+        {_, socket} ->
+           assign(socket, count: 0)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_server_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_server_counter_live.ex
@@ -9,8 +9,8 @@ defmodule ShowcaseAppWeb.E2eTest.LiveStashServerCounterLive do
         {:recovered, recovered_socket} ->
           recovered_socket
 
-        _ ->
-          assign(socket, count: 0)
+        {_, socket} ->
+           assign(socket, count: 0)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_client_tic_tac_toe_live.ex
@@ -20,11 +20,8 @@ defmodule ShowcaseAppWeb.Auth.LiveStashClientTicTacToeLive do
       {:recovered, recovered_socket} ->
         recovered_socket
 
-      {:error, socket} ->
-        socket
-        |> start_new_game()
-
-      _ -> start_new_game(socket)
+      {_, socket} ->
+        start_new_game(socket)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_client_tic_tac_toe_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.Auth.LiveStashClientTicTacToeLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, session_key: "user_token", ttl: 5000
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, session_key: "user_token"
 
   @winning_lines [
     [0, 1, 2],

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_client_tic_tac_toe_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.Auth.LiveStashClientTicTacToeLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, session_key: "user_token"
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, session_key: "user_token", ttl: 5000
 
   @winning_lines [
     [0, 1, 2],
@@ -19,6 +19,11 @@ defmodule ShowcaseAppWeb.Auth.LiveStashClientTicTacToeLive do
     |> case do
       {:recovered, recovered_socket} ->
         recovered_socket
+
+      {:error, socket} ->
+        socket
+        |> start_new_game()
+
       _ -> start_new_game(socket)
     end
     |> then(&{:ok, &1})

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_server_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/auth_live_stash_server_tic_tac_toe_live.ex
@@ -19,7 +19,9 @@ defmodule ShowcaseAppWeb.Auth.LiveStashServerTicTacToeLive do
     |> case do
       {:recovered, recovered_socket} ->
         recovered_socket
-      _ -> start_new_game(socket)
+
+      {_, socket} ->
+        start_new_game(socket)
     end
     |> then(&{:ok, &1})
   end

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
@@ -21,6 +21,7 @@ defmodule ShowcaseAppWeb.LiveStashClientTicTacToeLive do
     |> case do
       {:recovered, recovered_socket} ->
         recovered_socket
+
       {:error, socket} ->
         socket
         |> start_new_game()

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
@@ -22,11 +22,8 @@ defmodule ShowcaseAppWeb.LiveStashClientTicTacToeLive do
       {:recovered, recovered_socket} ->
         recovered_socket
 
-      {:error, socket} ->
-        socket
-        |> start_new_game()
-
-      _ -> start_new_game(socket)
+      {_, socket} ->
+        start_new_game(socket)
     end
     |> assign(is_embed: is_embed)
     |> then(&{:ok, &1})

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.LiveStashClientTicTacToeLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 2
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 5000
 
   @winning_lines [
     [0, 1, 2],

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.LiveStashClientTicTacToeLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 2
 
   @winning_lines [
     [0, 1, 2],
@@ -21,6 +21,10 @@ defmodule ShowcaseAppWeb.LiveStashClientTicTacToeLive do
     |> case do
       {:recovered, recovered_socket} ->
         recovered_socket
+      {:error, socket} ->
+        socket
+        |> start_new_game()
+
       _ -> start_new_game(socket)
     end
     |> assign(is_embed: is_embed)

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_client_tic_tac_toe_live.ex
@@ -1,6 +1,6 @@
 defmodule ShowcaseAppWeb.LiveStashClientTicTacToeLive do
   use ShowcaseAppWeb, :live_view
-  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt, ttl: 5000
+  use LiveStash, adapter: LiveStash.Adapters.BrowserMemory, security_mode: :encrypt
 
   @winning_lines [
     [0, 1, 2],

--- a/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_server_tic_tac_toe_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/tic_tac_toe/live_stash_server_tic_tac_toe_live.ex
@@ -19,7 +19,9 @@ defmodule ShowcaseAppWeb.LiveStashServerTicTacToeLive do
     |> case do
       {:recovered, recovered_socket} ->
         recovered_socket
-      _ -> start_new_game(socket)
+
+      {_, socket} ->
+        start_new_game(socket)
     end
     |> then(&{:ok, &1})
   end

--- a/lib/live_stash.ex
+++ b/lib/live_stash.ex
@@ -196,7 +196,9 @@ defmodule LiveStash do
         |> case do
           {:recovered, recovered_socket} ->
             recovered_socket
-          _ -> start_new_game(socket)
+
+          {_, socket} ->
+            start_new_game(socket)
         end
         |> then(&{:ok, &1})
       end

--- a/lib/live_stash.ex
+++ b/lib/live_stash.ex
@@ -39,8 +39,8 @@ defmodule LiveStash do
             # socket with previously stashed assigns is recovered
             recovered_socket
 
-          _ ->
-            # could not recover assigns, proceed with standard setup
+          {_, socket} ->
+            # could not recover assigns, proceed with standard setup using returned socket
             # ...
         end
         |> then(&{:ok, &1})

--- a/lib/live_stash/adapters/browser_memory/browser_memory.ex
+++ b/lib/live_stash/adapters/browser_memory/browser_memory.ex
@@ -91,10 +91,6 @@ defmodule LiveStash.Adapters.BrowserMemory do
             Logger.error(msg)
 
             socket
-            |> LiveView.put_private(:live_stash_context, %{
-              socket.private.live_stash_context
-              | key_set: MapSet.new()
-            })
             |> LiveView.push_event("live-stash:init-browser-memory", %{})
             |> then(&{:error, &1})
         end

--- a/lib/live_stash/adapters/browser_memory/browser_memory.ex
+++ b/lib/live_stash/adapters/browser_memory/browser_memory.ex
@@ -90,7 +90,12 @@ defmodule LiveStash.Adapters.BrowserMemory do
           {:error, msg} ->
             Logger.error(msg)
 
-            LiveView.push_event(socket, "live-stash:init-browser-memory", %{})
+            socket
+            |> LiveView.put_private(:live_stash_context, %{
+              socket.private.live_stash_context
+              | key_set: MapSet.new()
+            })
+            |> LiveView.push_event("live-stash:init-browser-memory", %{})
             |> then(&{:error, &1})
         end
 

--- a/lib/live_stash/adapters/browser_memory/browser_memory.ex
+++ b/lib/live_stash/adapters/browser_memory/browser_memory.ex
@@ -89,7 +89,9 @@ defmodule LiveStash.Adapters.BrowserMemory do
 
           {:error, msg} ->
             Logger.error(msg)
-            {:error, socket}
+
+            LiveView.push_event(socket, "live-stash:init-browser-memory", %{})
+            |> then(&{:error, &1})
         end
 
       _ ->

--- a/lib/live_stash/adapters/browser_memory/serializer.ex
+++ b/lib/live_stash/adapters/browser_memory/serializer.ex
@@ -49,7 +49,7 @@ defmodule LiveStash.Adapters.BrowserMemory.Serializer do
       _ ->
         msg =
           Utils.reason_message(
-            "Failed to decode stashed assign with key #{inspect(key)}. It may be missing or malformed.",
+            "Failed to decode stashed assign with key #{inspect(key)}. It may be expired, missing or malformed.",
             :error
           )
 

--- a/test/live_stash/adapters/browser_memory/browser_memory_test.exs
+++ b/test/live_stash/adapters/browser_memory/browser_memory_test.exs
@@ -132,7 +132,8 @@ defmodule LiveStash.Adapters.BrowserMemoryTest do
       assert returned_socket == socket
     end
 
-    test "returns :error and logs warning when token decryption fails", %{socket: socket} do
+    test "returns :error, logs warning and pushes init-browser-memory event when token decryption fails",
+         %{socket: socket} do
       socket = put_in(socket.private.live_stash_context.reconnected?, true)
 
       params = %{
@@ -148,7 +149,14 @@ defmodule LiveStash.Adapters.BrowserMemoryTest do
 
       log =
         capture_log(fn ->
-          assert {:error, _socket} = BrowserMemory.recover_state(socket_with_params)
+          assert {:error, returned_socket} = BrowserMemory.recover_state(socket_with_params)
+
+          queued_events = get_in(returned_socket.private, [:live_temp, :push_events]) || []
+
+          assert Enum.any?(queued_events, fn
+                   ["live-stash:init-browser-memory", payload] -> payload == %{}
+                   _other -> false
+                 end)
         end)
 
       assert log =~ "Failed to retrieve key set"


### PR DESCRIPTION
After receiving bad key-value pair from the browser, we would log an error and return socket with no recovered assigns, but that bad state has to be cleared or it will persist between reconnects.