### PR TITLE
Enhancement: Support for LiveComponents

### DIFF
--- a/examples/showcase_app/e2e/bad_state.spec.js
+++ b/examples/showcase_app/e2e/bad_state.spec.js
@@ -17,6 +17,9 @@ test.describe("ETS & Browser memory adapters - state recovery with bad state", (
       const incrementBtn = page.getByLabel("Increment");
       const counterValue = page.locator(".stat-value");
 
+      const componentIncrementBtn = page.getByLabel("Component Plus");
+      const componentCounterValue = page.getByTestId("component-count");
+
       await page.waitForFunction(
         () => window.liveSocket && window.liveSocket.isConnected(),
       );
@@ -51,6 +54,9 @@ test.describe("ETS & Browser memory adapters - state recovery with bad state", (
 
       await incrementBtn.click();
       await expect(counterValue).toHaveText("1");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("1");
     });
   });
 });

--- a/examples/showcase_app/e2e/cluster_browser_memory.spec.js
+++ b/examples/showcase_app/e2e/cluster_browser_memory.spec.js
@@ -11,6 +11,9 @@ test.describe("Browser memory adapter - state recovery on cluster", () => {
     const incrementBtn = page.getByLabel("Increment");
     const counterValue = page.locator(".stat-value");
 
+    const componentIncrementBtn = page.getByLabel("Component Plus");
+    const componentCounterValue = page.getByTestId("component-count");
+
     await page.waitForFunction(
       () => window.liveSocket && window.liveSocket.isConnected(),
     );
@@ -22,6 +25,12 @@ test.describe("Browser memory adapter - state recovery on cluster", () => {
 
     await incrementBtn.click();
     await expect(counterValue).toHaveText("2");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("1");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("2");
 
     await page.evaluate(() => window.liveSocket.disconnect());
 
@@ -38,5 +47,6 @@ test.describe("Browser memory adapter - state recovery on cluster", () => {
     await expect(page.locator(".phx-connected").first()).toBeVisible();
 
     await expect(counterValue).toHaveText("2");
+    await expect(componentCounterValue).toHaveText("2");
   });
 });

--- a/examples/showcase_app/e2e/cluster_ets.spec.js
+++ b/examples/showcase_app/e2e/cluster_ets.spec.js
@@ -11,6 +11,9 @@ test.describe("ETS adapter - state recovery on cluster", () => {
     const incrementBtn = page.getByLabel("Increment");
     const counterValue = page.locator(".stat-value");
 
+    const componentIncrementBtn = page.getByLabel("Component Plus");
+    const componentCounterValue = page.getByTestId("component-count");
+
     await page.waitForFunction(
       () => window.liveSocket && window.liveSocket.isConnected(),
     );
@@ -22,6 +25,12 @@ test.describe("ETS adapter - state recovery on cluster", () => {
 
     await incrementBtn.click();
     await expect(counterValue).toHaveText("2");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("1");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("2");
 
     await page.evaluate(() => window.liveSocket.disconnect());
 
@@ -37,5 +46,6 @@ test.describe("ETS adapter - state recovery on cluster", () => {
 
     await expect(page.locator(".phx-connected").first()).toBeVisible();
     await expect(counterValue).toHaveText("2");
+    await expect(componentCounterValue).toHaveText("2");
   });
 });

--- a/examples/showcase_app/e2e/fingerprint.spec.js
+++ b/examples/showcase_app/e2e/fingerprint.spec.js
@@ -19,6 +19,9 @@ test.describe("Browser memory adapter - fingerprint optimization", () => {
     const addZeroBtn = page.getByLabel("Add Zero");
     const counterValue = page.locator(".stat-value");
 
+    const componentIncrementBtn = page.getByLabel("Component Plus");
+    const componentCounterValue = page.getByTestId("component-count");
+
     await page.waitForFunction(
       () => window.liveSocket && window.liveSocket.isConnected(),
     );
@@ -38,7 +41,24 @@ test.describe("Browser memory adapter - fingerprint optimization", () => {
     await page.waitForTimeout(200);
 
     const stashCountAfterZero = await page.evaluate(() => window.__stashCount);
-
     expect(stashCountAfterZero).toBe(1);
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("1");
+
+    await expect(async () => {
+      const count = await page.evaluate(() => window.__stashCount);
+      expect(count).toBe(2);
+    }).toPass();
+
+    await addZeroBtn.click();
+    await expect(counterValue).toHaveText("1");
+
+    await page.waitForTimeout(200);
+
+    const stashCountAfterFinalZero = await page.evaluate(
+      () => window.__stashCount,
+    );
+    expect(stashCountAfterFinalZero).toBe(2);
   });
 });

--- a/examples/showcase_app/e2e/not_reconnected.spec.js
+++ b/examples/showcase_app/e2e/not_reconnected.spec.js
@@ -17,6 +17,9 @@ test.describe("ETS & Browser memory adapters- not reconnected", () => {
       const incrementBtn = page.getByLabel("Increment");
       const counterValue = page.locator(".stat-value");
 
+      const componentIncrementBtn = page.getByLabel("Component Plus");
+      const componentCounterValue = page.getByTestId("component-count");
+
       await page.waitForFunction(
         () => window.liveSocket && window.liveSocket.isConnected(),
       );
@@ -26,6 +29,12 @@ test.describe("ETS & Browser memory adapters- not reconnected", () => {
 
       await incrementBtn.click();
       await expect(counterValue).toHaveText("2");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("1");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("2");
 
       await page.goto("/");
       await page.goto(route);
@@ -45,6 +54,7 @@ test.describe("ETS & Browser memory adapters- not reconnected", () => {
       await expect(page.locator(".phx-connected").first()).toBeVisible();
 
       await expect(counterValue).toHaveText("0");
+      await expect(componentCounterValue).toHaveText("0");
     });
   });
 });

--- a/examples/showcase_app/e2e/reconnect.spec.js
+++ b/examples/showcase_app/e2e/reconnect.spec.js
@@ -9,13 +9,16 @@ test.describe("ETS & Browser memory adapters - state recovery after reconnect", 
   test.use({ baseURL: "http://localhost:4000" });
 
   routes.forEach((route) => {
-    test(`should recover counter state after websocket reconnect on ${route}`, async ({
+    test(`should recover root and component counter state after websocket reconnect on ${route}`, async ({
       page,
     }) => {
       await page.goto(route);
 
       const incrementBtn = page.getByLabel("Increment");
       const counterValue = page.locator(".stat-value");
+
+      const componentIncrementBtn = page.getByLabel("Component Plus");
+      const componentCounterValue = page.getByTestId("component-count");
 
       await page.waitForFunction(
         () => window.liveSocket && window.liveSocket.isConnected(),
@@ -28,6 +31,15 @@ test.describe("ETS & Browser memory adapters - state recovery after reconnect", 
 
       await incrementBtn.click();
       await expect(counterValue).toHaveText("2");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("1");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("2");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("3");
 
       await page.evaluate(() => window.liveSocket.disconnect());
 
@@ -44,6 +56,7 @@ test.describe("ETS & Browser memory adapters - state recovery after reconnect", 
       await expect(page.locator(".phx-connected").first()).toBeVisible();
 
       await expect(counterValue).toHaveText("2");
+      await expect(componentCounterValue).toHaveText("3");
     });
   });
 });

--- a/examples/showcase_app/e2e/reset_stash.spec.js
+++ b/examples/showcase_app/e2e/reset_stash.spec.js
@@ -18,6 +18,9 @@ test.describe("ETS & Browser memory adapters - reset stash", () => {
       const resetStashBtn = page.getByLabel("Reset Stash");
       const counterValue = page.locator(".stat-value");
 
+      const componentIncrementBtn = page.getByLabel("Component Plus");
+      const componentCounterValue = page.getByTestId("component-count");
+
       await page.waitForFunction(
         () => window.liveSocket && window.liveSocket.isConnected(),
       );
@@ -29,6 +32,12 @@ test.describe("ETS & Browser memory adapters - reset stash", () => {
 
       await incrementBtn.click();
       await expect(counterValue).toHaveText("2");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("1");
+
+      await componentIncrementBtn.click();
+      await expect(componentCounterValue).toHaveText("2");
 
       await resetStashBtn.click();
       await expect(counterValue).toHaveText("0");
@@ -48,6 +57,7 @@ test.describe("ETS & Browser memory adapters - reset stash", () => {
       await expect(page.locator(".phx-connected").first()).toBeVisible();
 
       await expect(counterValue).toHaveText("0");
+      await expect(componentCounterValue).toHaveText("0");
     });
   });
 });

--- a/examples/showcase_app/e2e/ttl_expired_browser_memory.spec.js
+++ b/examples/showcase_app/e2e/ttl_expired_browser_memory.spec.js
@@ -11,6 +11,9 @@ test.describe("Browser memory adapter - TTL expiration", () => {
     const incrementBtn = page.getByLabel("Increment");
     const counterValue = page.locator(".stat-value");
 
+    const componentIncrementBtn = page.getByLabel("Component Plus");
+    const componentCounterValue = page.getByTestId("component-count");
+
     await page.waitForFunction(
       () => window.liveSocket && window.liveSocket.isConnected(),
     );
@@ -22,6 +25,12 @@ test.describe("Browser memory adapter - TTL expiration", () => {
 
     await incrementBtn.click();
     await expect(counterValue).toHaveText("2");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("1");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("2");
 
     await page.waitForTimeout(2000);
 
@@ -40,5 +49,6 @@ test.describe("Browser memory adapter - TTL expiration", () => {
     await expect(page.locator(".phx-connected").first()).toBeVisible();
 
     await expect(counterValue).toHaveText("0");
+    await expect(componentCounterValue).toHaveText("0");
   });
 });

--- a/examples/showcase_app/e2e/ttl_expired_ets.spec.js
+++ b/examples/showcase_app/e2e/ttl_expired_ets.spec.js
@@ -11,6 +11,9 @@ test.describe("ETS adapter - TTL expiration", () => {
     const incrementBtn = page.getByLabel("Increment");
     const counterValue = page.locator(".stat-value");
 
+    const componentIncrementBtn = page.getByLabel("Component Plus");
+    const componentCounterValue = page.getByTestId("component-count");
+
     await page.waitForFunction(
       () => window.liveSocket && window.liveSocket.isConnected(),
     );
@@ -22,6 +25,12 @@ test.describe("ETS adapter - TTL expiration", () => {
 
     await incrementBtn.click();
     await expect(counterValue).toHaveText("2");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("1");
+
+    await componentIncrementBtn.click();
+    await expect(componentCounterValue).toHaveText("2");
 
     await page.evaluate(() => window.liveSocket.disconnect());
 
@@ -40,5 +49,6 @@ test.describe("ETS adapter - TTL expiration", () => {
     await expect(page.locator(".phx-connected").first()).toBeVisible();
 
     await expect(counterValue).toHaveText("0");
+    await expect(componentCounterValue).toHaveText("0");
   });
 });

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_counter_live.ex
@@ -1,3 +1,23 @@
+defmodule MojKomponent do
+  use Phoenix.LiveComponent
+
+  def mount(socket) do
+    IO.inspect(socket, label: "🚀 socket W MOUNT", limit: :infinity, printable_limit: :infinity, structs: false)
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+          ~H"""
+      <div>live component</div>
+      """
+  end
+
+  def update(assigns, socket) do
+    IO.inspect(assigns, label: "📦 ASSIGNS W UPDATE")
+    {:ok, assign(socket, assigns)}
+  end
+end
+
 defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
   use ShowcaseAppWeb, :live_view
   use LiveStash, stored_keys: [:count]
@@ -19,6 +39,7 @@ defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
   def render(assigns) do
     ~H"""
     <div class="flex py-10 items-center justify-center p-4">
+    <.live_component module={MojKomponent} id="moj-komponent" />
       <div class="card bg-base-100 shadow-xl w-full max-w-md">
         <.return_link />
 

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_counter_live.ex
@@ -2,6 +2,7 @@ defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
   use ShowcaseAppWeb, :live_view
   use LiveStash, stored_keys: [:count]
 
+
   def mount(_params, _session, socket) do
     socket
     |> LiveStash.recover_state()

--- a/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/counter/live_stash_counter_live.ex
@@ -1,27 +1,6 @@
-defmodule MojKomponent do
-  use Phoenix.LiveComponent
-
-  def mount(socket) do
-    IO.inspect(socket, label: "🚀 socket W MOUNT", limit: :infinity, printable_limit: :infinity, structs: false)
-    {:ok, socket}
-  end
-
-  def render(assigns) do
-          ~H"""
-      <div>live component</div>
-      """
-  end
-
-  def update(assigns, socket) do
-    IO.inspect(assigns, label: "📦 ASSIGNS W UPDATE")
-    {:ok, assign(socket, assigns)}
-  end
-end
-
 defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
   use ShowcaseAppWeb, :live_view
   use LiveStash, stored_keys: [:count]
-
 
   def mount(_params, _session, socket) do
     socket
@@ -39,7 +18,6 @@ defmodule ShowcaseAppWeb.LiveStashServerCounterLive do
   def render(assigns) do
     ~H"""
     <div class="flex py-10 items-center justify-center p-4">
-    <.live_component module={MojKomponent} id="moj-komponent" />
       <div class="card bg-base-100 shadow-xl w-full max-w-md">
         <.return_link />
 

--- a/examples/showcase_app/lib/showcase_app_web/live/e2e_test/counter_component.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/e2e_test/counter_component.ex
@@ -1,0 +1,61 @@
+defmodule ShowcaseAppWeb.E2eTest.CounterComponent do
+  use ShowcaseAppWeb, :live_component
+  use LiveStash.Component, stored_keys: [:component_count]
+
+  def mount(socket) do
+    {:ok, assign(socket, :component_count, 0)}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="card bg-base-100 shadow-xl w-full max-w-md mt-6" data-testid="counter-component">
+      <div class="card-body items-center text-center">
+        <h2 class="card-title text-2xl mb-2">Component Counter</h2>
+
+        <div class="bg-base-200 rounded-lg px-8 py-4 my-4">
+          <div
+            class="text-4xl font-bold text-secondary"
+            data-testid="component-count"
+          >
+            {@component_count}
+          </div>
+          <div class="text-sm opacity-70">Component Count</div>
+        </div>
+
+        <div class="card-actions justify-center gap-4 mt-2">
+          <button
+            phx-click="component_decrement"
+            phx-target={@myself}
+            class="btn btn-circle btn-outline btn-error"
+            aria-label="Component Minus"
+          >
+            -
+          </button>
+          <button
+            phx-click="component_increment"
+            phx-target={@myself}
+            class="btn btn-circle btn-secondary"
+            aria-label="Component Plus"
+          >
+            +
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def handle_event("component_increment", _, socket) do
+    socket
+    |> assign(:component_count, socket.assigns.component_count + 1)
+    |> LiveStash.Component.stash()
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event("component_decrement", _, socket) do
+    socket
+    |> assign(:component_count, socket.assigns.component_count - 1)
+    |> LiveStash.Component.stash()
+    |> then(&{:noreply, &1})
+  end
+end

--- a/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_client_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_client_counter_live.ex
@@ -21,7 +21,7 @@ defmodule ShowcaseAppWeb.E2eTest.LiveStashClientCounterLive do
 
   def render(assigns) do
     ~H"""
-    <div class="min-h-screen bg-base-200 flex items-center justify-center p-4">
+    <div class="min-h-screen bg-base-200 flex flex-col items-center justify-center p-4">
       <div class="card bg-base-100 shadow-xl w-full max-w-md">
         <.return_link />
 
@@ -78,6 +78,9 @@ defmodule ShowcaseAppWeb.E2eTest.LiveStashClientCounterLive do
           </div>
         </div>
       </div>
+
+      <.live_component module={ShowcaseAppWeb.E2eTest.CounterComponent} id="client-counter-component" />
+
       <button
         phx-click="reset_stash"
         class="btn btn-sm bg-base-300 border border-neutral-600 text-neutral-400 hover:bg-neutral-700/30 fixed bottom-6 right-48 z-50 shadow-2xl font-mono text-xs rounded-full px-4 transition-colors"

--- a/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_server_counter_live.ex
+++ b/examples/showcase_app/lib/showcase_app_web/live/e2e_test/live_stash_server_counter_live.ex
@@ -17,7 +17,7 @@ defmodule ShowcaseAppWeb.E2eTest.LiveStashServerCounterLive do
 
   def render(assigns) do
     ~H"""
-    <div class="min-h-screen bg-base-200 flex items-center justify-center p-4">
+    <div class="min-h-screen bg-base-200 flex flex-col items-center justify-center p-4">
       <div class="card bg-base-100 shadow-xl w-full max-w-md">
         <.return_link />
 
@@ -74,6 +74,9 @@ defmodule ShowcaseAppWeb.E2eTest.LiveStashServerCounterLive do
           </div>
         </div>
       </div>
+
+      <.live_component module={ShowcaseAppWeb.E2eTest.CounterComponent} id="server-counter-component" />
+
       <button
         phx-click="reset_stash"
         class="btn btn-sm bg-base-300 border border-neutral-600 text-neutral-400 hover:bg-neutral-700/30 fixed bottom-6 right-48 z-50 shadow-2xl font-mono text-xs rounded-full px-4 transition-colors"

--- a/lib/live_stash.ex
+++ b/lib/live_stash.ex
@@ -114,9 +114,67 @@ defmodule LiveStash do
   lifecycle.
   """
   def on_mount(opts, _params, session, socket) do
-    socket = init_stash(socket, session, opts)
+    socket =
+      socket
+      |> init_stash(session, opts)
+      |> attach_component_stash_hook()
 
     {:cont, socket}
+  end
+
+  @doc false
+  # Attaches a handle_info hook that receives stash messages from
+  # LiveStash-aware components rendered under this LiveView. The hook updates
+  # the in-memory components buffer in socket.private and triggers an adapter
+  # stash so the merged blob (root assigns + components map) is persisted.
+  def attach_component_stash_hook(socket) do
+    LiveView.attach_hook(
+      socket,
+      :live_stash_component_stash,
+      :handle_info,
+      &handle_component_stash/2
+    )
+  end
+
+  defp handle_component_stash(
+         {:live_stash_component_stash, key, assigns_to_stash},
+         socket
+       ) do
+    buffer = socket.private[:live_stash_components_buffer] || %{}
+    new_buffer = Map.put(buffer, key, assigns_to_stash)
+
+    socket =
+      socket
+      |> LiveView.put_private(:live_stash_components_buffer, new_buffer)
+      |> stash()
+
+    {:halt, socket}
+  end
+
+  defp handle_component_stash(_msg, socket), do: {:cont, socket}
+
+  @doc """
+  Populates the process dictionary with recovered component state.
+
+  Called by adapters during `recover_state/1` so that LiveStash-aware
+  `Phoenix.LiveComponent`s can read their slice on first `update/2` (see
+  `LiveStash.Component`). The map is keyed by `{component_module, id}`.
+  """
+  @spec put_recovered_components(map()) :: :ok
+  def put_recovered_components(components_map) when is_map(components_map) do
+    Process.put(:live_stash_components, components_map)
+    :ok
+  end
+
+  @doc """
+  Returns the components buffer accumulated from component stash messages.
+
+  Adapters use this during `stash/1` to merge component state into the blob
+  alongside the LiveView's own stored assigns.
+  """
+  @spec get_components_buffer(Socket.t()) :: map()
+  def get_components_buffer(socket) do
+    socket.private[:live_stash_components_buffer] || %{}
   end
 
   @doc """

--- a/lib/live_stash/adapters/browser_memory/browser_memory.ex
+++ b/lib/live_stash/adapters/browser_memory/browser_memory.ex
@@ -36,15 +36,17 @@ defmodule LiveStash.Adapters.BrowserMemory do
   def stash(socket) do
     context = socket.private.live_stash_context
     keys = context.stored_keys
-    assigns_to_stash = Map.take(socket.assigns, keys)
-    new_fingerprint = Utils.hash_term(assigns_to_stash)
+    root_assigns = Map.take(socket.assigns, keys)
+    components = LiveStash.get_components_buffer(socket)
+    blob = %{root: root_assigns, components: components}
+    new_fingerprint = Utils.hash_term(blob)
 
     if new_fingerprint != context.stash_fingerprint do
-      serialized_assigns =
-        Serializer.encode_token(socket, assigns_to_stash, get_settings(socket))
+      serialized_blob =
+        Serializer.encode_token(socket, blob, get_settings(socket))
 
       payload = %{
-        "assigns" => serialized_assigns
+        "assigns" => serialized_blob
       }
 
       new_context = %{context | stash_fingerprint: new_fingerprint}
@@ -61,14 +63,16 @@ defmodule LiveStash.Adapters.BrowserMemory do
   def recover_state(%{private: %{live_stash_context: %Context{reconnected?: true}}} = socket) do
     with %{"liveStash" => %{"stashedState" => stashed_state}} when is_binary(stashed_state) <-
            LiveView.get_connect_params(socket),
-         {:ok, recovered_state} <-
+         {:ok, %{root: root_state, components: components_state} = blob} <-
            Serializer.decode_token(socket, stashed_state, get_settings(socket)) do
+      LiveStash.put_recovered_components(components_state)
+
       context = socket.private.live_stash_context
-      fingerprint = Utils.hash_term(recovered_state)
+      fingerprint = Utils.hash_term(blob)
       updated_context = %{context | stash_fingerprint: fingerprint}
 
       socket
-      |> Component.assign(recovered_state)
+      |> Component.assign(root_state)
       |> LiveView.put_private(:live_stash_context, updated_context)
       |> then(&{:recovered, &1})
     else

--- a/lib/live_stash/adapters/browser_memory/browser_memory.ex
+++ b/lib/live_stash/adapters/browser_memory/browser_memory.ex
@@ -74,6 +74,7 @@ defmodule LiveStash.Adapters.BrowserMemory do
       socket
       |> Component.assign(root_state)
       |> LiveView.put_private(:live_stash_context, updated_context)
+      |> LiveView.put_private(:live_stash_components_buffer, components_state)
       |> then(&{:recovered, &1})
     else
       {:error, reason} ->
@@ -116,6 +117,7 @@ defmodule LiveStash.Adapters.BrowserMemory do
     socket
     |> LiveView.push_event("live-stash:init-browser-memory", %{})
     |> LiveView.put_private(:live_stash_context, updated_context)
+    |> LiveView.put_private(:live_stash_components_buffer, %{})
   end
 
   defp get_settings(socket) do

--- a/lib/live_stash/adapters/ets/ets.ex
+++ b/lib/live_stash/adapters/ets/ets.ex
@@ -64,11 +64,13 @@ defmodule LiveStash.Adapters.ETS do
   def stash(socket) do
     context = socket.private.live_stash_context
     keys = context.stored_keys
-    assigns_to_stash = Map.take(socket.assigns, keys)
-    new_fingerprint = Utils.hash_term(assigns_to_stash)
+    root_assigns = Map.take(socket.assigns, keys)
+    components = LiveStash.get_components_buffer(socket)
+    blob = %{root: root_assigns, components: components}
+    new_fingerprint = Utils.hash_term(blob)
 
     if new_fingerprint != context.stash_fingerprint do
-      State.put!(get_ets_id(socket), assigns_to_stash, get_opts(socket))
+      State.put!(get_ets_id(socket), blob, get_opts(socket))
 
       new_context = %{context | stash_fingerprint: new_fingerprint}
 
@@ -85,19 +87,24 @@ defmodule LiveStash.Adapters.ETS do
     node_hint = socket.private.live_stash_context.node_hint
 
     case StateFinder.get_from_cluster(id, node_hint) do
-      {:ok, recovered_state} ->
+      {:ok, %{root: root_state, components: components_state} = blob} ->
         id
-        |> State.new(recovered_state, get_opts(socket))
+        |> State.new(blob, get_opts(socket))
         |> State.insert!()
 
+        LiveStash.put_recovered_components(components_state)
+
         context = socket.private.live_stash_context
-        fingerprint = Utils.hash_term(recovered_state)
+        fingerprint = Utils.hash_term(blob)
         updated_context = %{context | stash_fingerprint: fingerprint}
 
         socket
-        |> Component.assign(recovered_state)
+        |> Component.assign(root_state)
         |> LiveView.put_private(:live_stash_context, updated_context)
         |> then(&{:recovered, &1})
+
+      {:ok, _legacy} ->
+        {:not_found, socket}
 
       :not_found ->
         {:not_found, socket}

--- a/lib/live_stash/adapters/ets/ets.ex
+++ b/lib/live_stash/adapters/ets/ets.ex
@@ -101,6 +101,7 @@ defmodule LiveStash.Adapters.ETS do
         socket
         |> Component.assign(root_state)
         |> LiveView.put_private(:live_stash_context, updated_context)
+        |> LiveView.put_private(:live_stash_components_buffer, components_state)
         |> then(&{:recovered, &1})
 
       {:ok, _legacy} ->
@@ -128,7 +129,9 @@ defmodule LiveStash.Adapters.ETS do
     |> get_ets_id()
     |> State.delete_by_id!()
 
-    LiveView.put_private(socket, :live_stash_context, updated_context)
+    socket
+    |> LiveView.put_private(:live_stash_context, updated_context)
+    |> LiveView.put_private(:live_stash_components_buffer, %{})
   rescue
     error ->
       err = Utils.exception_message("Could not reset stash", error, __STACKTRACE__)

--- a/lib/live_stash/adapters/ets/state.ex
+++ b/lib/live_stash/adapters/ets/state.ex
@@ -80,7 +80,7 @@ defmodule LiveStash.Adapters.ETS.State do
     new_record = new(id, state, opts)
 
     match_spec = [
-      {{:state, id, pid, :_, :_, :_}, [], [{new_record}]}
+      {{:state, id, pid, :_, :_, :_}, [], [{:const, new_record}]}
     ]
 
     if :ets.select_replace(@table_name, match_spec) == 0 do

--- a/lib/live_stash/live_stash_component.ex
+++ b/lib/live_stash/live_stash_component.ex
@@ -1,0 +1,42 @@
+defmodule LiveStash.Component do
+  defmacro __using__(_opts) do
+    quote do
+      def update(assigns, socket) do
+        socket =
+          socket
+          |> assign(assigns)
+          |> LiveStash.Component.inject_stash_recovery()
+
+        {:ok, socket}
+      end
+
+      defoverridable update: 2
+    end
+  end
+
+  @doc false
+  def inject_stash_recovery(socket) do
+    if socket.assigns[:__live_stash_recovered__] do
+      socket
+    else
+      stashed_state = socket.assigns[:recovered_state] || %{}
+
+      socket
+      |> Phoenix.Component.assign(:__live_stash_recovered__, true)
+      |> Phoenix.Component.assign(stashed_state)
+    end
+  end
+end
+
+defmodule ShowcaseAppWeb.MyCounterComponent do
+  use Phoenix.LiveComponent
+  use LiveStash.Component
+
+  def update(assigns, socket) do
+    {:ok, socket} = super(assigns, socket)
+
+    {:ok, assign(socket, :inna_zmienna, 123)}
+  end
+
+  # def render(assigns) do ... end
+end

--- a/lib/live_stash/live_stash_component.ex
+++ b/lib/live_stash/live_stash_component.ex
@@ -1,42 +1,201 @@
 defmodule LiveStash.Component do
-  defmacro __using__(_opts) do
+  @moduledoc """
+  LiveStash support for `Phoenix.LiveComponent`.
+
+  A LiveComponent has no `connect_params` of its own and its `mount/1` runs
+  with an empty socket — neither the parent-supplied `id` nor the user's
+  assigns are available there. The earliest moment a component has a stable
+  identity is its first `update/2` call, so recovery is gated on that.
+
+  ## Usage
+
+      defmodule MyCounterComponent do
+        use Phoenix.LiveComponent
+        use LiveStash.Component, stored_keys: [:count]
+
+        def mount(socket) do
+          # Defaults. If `:count` is recovered later, this value is overridden.
+          {:ok, assign(socket, :count, 0)}
+        end
+
+        # Optional. Runs once after recovery, before first render.
+        def mount_stashed(socket) do
+          if socket.private[:live_stash_recovered?] do
+            socket
+          else
+            kick_off_initial_load(socket)
+          end
+        end
+
+        # Optional. If defined, must call super first.
+        def update(assigns, socket) do
+          {:ok, socket} = super(assigns, socket)
+          {:ok, react_to_assigns(socket, assigns)}
+        end
+
+        def handle_event("inc", _, socket) do
+          socket
+          |> assign(:count, socket.assigns.count + 1)
+          |> LiveStash.Component.stash()
+          |> then(&{:noreply, &1})
+        end
+      end
+
+  ## Lifecycle
+
+  On the first `update/2`:
+
+  1. Macro-generated wrapper reads recovered state for `{__MODULE__, assigns.id}`
+     from the parent LiveView's process dictionary (populated by the root's
+     adapter during `LiveStash.recover_state/1`).
+  2. Recovered keys are merged into `socket.assigns`. The entry is deleted from
+     the process dictionary.
+  3. `socket.private[:live_stash_recovered?]` is set to `true` (recovered) or
+     `false` (no state found).
+  4. `mount_stashed/1` runs if defined.
+  5. Parent `assigns` are merged via the default `update/2` body.
+
+  On subsequent `update/2` calls, the flag is already set and the macro skips
+  recovery entirely.
+
+  ## The `:live_stash_recovered?` flag
+
+  Stored in `socket.private`, never in `socket.assigns` (would otherwise be
+  shipped to the client and pollute change tracking). Three states:
+
+    * `nil` — recovery hasn't run yet.
+    * `true` — recovery ran and a slice was found.
+    * `false` — recovery ran and nothing was found.
+
+  Read from your own `update/2` or `mount_stashed/1` if you need to branch on
+  recovery status.
+  """
+
+  alias Phoenix.Component
+  alias Phoenix.LiveView
+  alias Phoenix.LiveView.Socket
+
+  alias LiveStash.Utils
+
+  @doc false
+  defmacro __using__(opts) do
     quote do
+      @live_stash_component_opts unquote(opts)
+
       def update(assigns, socket) do
         socket =
-          socket
-          |> assign(assigns)
-          |> LiveStash.Component.inject_stash_recovery()
+          LiveStash.Component.__before_update__(
+            socket,
+            assigns,
+            @live_stash_component_opts,
+            __MODULE__
+          )
 
-        {:ok, socket}
+        {:ok, Phoenix.Component.assign(socket, assigns)}
       end
 
       defoverridable update: 2
     end
   end
 
-  @doc false
-  def inject_stash_recovery(socket) do
-    if socket.assigns[:__live_stash_recovered__] do
+  @doc """
+  Recovers stashed state on the first `update/2` call and runs `mount_stashed/1`.
+
+  Internal — invoked by the macro-generated `update/2`. Idempotent: the
+  `:live_stash_recovered?` private flag gates this so subsequent calls return
+  the socket untouched.
+  """
+  @spec __before_update__(Socket.t(), map(), keyword(), module()) :: Socket.t()
+  def __before_update__(socket, assigns, opts, module) do
+    if socket.private[:live_stash_recovered?] != nil do
       socket
     else
-      stashed_state = socket.assigns[:recovered_state] || %{}
+      id = fetch_id!(assigns, module)
+      key = {module, id}
 
-      socket
-      |> Phoenix.Component.assign(:__live_stash_recovered__, true)
-      |> Phoenix.Component.assign(stashed_state)
+      socket =
+        socket
+        |> LiveView.put_private(:live_stash_component_module, module)
+        |> LiveView.put_private(:live_stash_component_opts, opts)
+
+      stash_map = Process.get(:live_stash_components, %{})
+
+      socket =
+        case Map.pop(stash_map, key) do
+          {nil, _rest} ->
+            LiveView.put_private(socket, :live_stash_recovered?, false)
+
+          {recovered_assigns, rest} ->
+            Process.put(:live_stash_components, rest)
+
+            socket
+            |> Component.assign(recovered_assigns)
+            |> LiveView.put_private(:live_stash_recovered?, true)
+        end
+
+      if function_exported?(module, :mount_stashed, 1) do
+        module.mount_stashed(socket)
+      else
+        socket
+      end
     end
   end
-end
 
-defmodule ShowcaseAppWeb.MyCounterComponent do
-  use Phoenix.LiveComponent
-  use LiveStash.Component
+  @doc """
+  Stashes the component's `stored_keys` by sending an upstream message to the
+  root LiveView, which is responsible for persisting the merged blob.
 
-  def update(assigns, socket) do
-    {:ok, socket} = super(assigns, socket)
+  Use this from a component the same way you'd use `LiveStash.stash/1` from a
+  LiveView — typically after a state-changing event:
 
-    {:ok, assign(socket, :inna_zmienna, 123)}
+      def handle_event("inc", _, socket) do
+        socket
+        |> assign(:count, socket.assigns.count + 1)
+        |> LiveStash.Component.stash()
+        |> then(&{:noreply, &1})
+      end
+  """
+  @spec stash(Socket.t()) :: Socket.t()
+  def stash(socket) do
+    module = fetch_private!(socket, :live_stash_component_module)
+    opts = fetch_private!(socket, :live_stash_component_opts)
+    id = fetch_id!(socket.assigns, module)
+    keys = Keyword.fetch!(opts, :stored_keys)
+
+    assigns_to_stash = Map.take(socket.assigns, keys)
+    send(socket.root_pid, {:live_stash_component_stash, {module, id}, assigns_to_stash})
+
+    socket
   end
 
-  # def render(assigns) do ... end
+  defp fetch_private!(socket, key) do
+    case socket.private[key] do
+      nil ->
+        msg =
+          Utils.reason_message(
+            "LiveStash.Component.stash/1 called outside of a LiveStash component context. " <>
+              "Missing private key: #{inspect(key)}. Did you `use LiveStash.Component` in the component module?",
+            :invalid
+          )
+
+        raise ArgumentError, msg
+
+      value ->
+        value
+    end
+  end
+
+  defp fetch_id!(%{id: id}, _module) when is_binary(id) or is_integer(id), do: to_string(id)
+
+  defp fetch_id!(_assigns, module) do
+    msg =
+      Utils.reason_message(
+        "LiveStash.Component requires an `id` assign to be passed in the component's assigns. " <>
+          "No `id` found for #{inspect(module)}. Please ensure the component is rendered with an `id`: " <>
+          "<.live_component module={#{inspect(module)}} id=\"...\" />",
+        :invalid
+      )
+
+    raise ArgumentError, msg
+  end
 end

--- a/test/live_stash/adapters/browser_memory/browser_memory_test.exs
+++ b/test/live_stash/adapters/browser_memory/browser_memory_test.exs
@@ -132,10 +132,10 @@ defmodule LiveStash.Adapters.BrowserMemoryTest do
         security_mode: context.security_mode
       }
 
-      assert {:ok, recovered_assigns} =
+      assert {:ok, decoded_blob} =
                Serializer.decode_token(socket, payload["assigns"], settings)
 
-      assert recovered_assigns == %{username: "tester"}
+      assert decoded_blob == %{root: %{username: "tester"}, components: %{}}
     end
   end
 
@@ -150,7 +150,12 @@ defmodule LiveStash.Adapters.BrowserMemoryTest do
         security_mode: :sign
       }
 
-      stashed_state = Serializer.encode_token(socket, %{player_id: 999}, settings)
+      stashed_state =
+        Serializer.encode_token(
+          socket,
+          %{root: %{player_id: 999}, components: %{}},
+          settings
+        )
 
       params = %{
         "liveStash" => %{

--- a/test/live_stash/adapters/ets/ets_test.exs
+++ b/test/live_stash/adapters/ets/ets_test.exs
@@ -122,7 +122,7 @@ defmodule LiveStash.Adapters.ETSTest do
       assert %Socket{} = returned_socket
 
       assert {:ok, saved_state} = StateFinder.get_from_cluster(ets_id, Node.self())
-      assert saved_state == %{username: "tester"}
+      assert saved_state == %{root: %{username: "tester"}, components: %{}}
     end
 
     test "does not update ETS when only untracked assigns change - fingerprint remains the same",
@@ -144,7 +144,9 @@ defmodule LiveStash.Adapters.ETSTest do
       [record_after] = :ets.lookup(@table_name, ets_id)
 
       assert record_before == record_after
-      assert {:ok, %{username: "tester"}} = StateFinder.get_from_cluster(ets_id, Node.self())
+
+      assert {:ok, %{root: %{username: "tester"}, components: %{}}} =
+               StateFinder.get_from_cluster(ets_id, Node.self())
     end
 
     test "updates state when stashed assigns fingerprint changes", %{
@@ -158,7 +160,7 @@ defmodule LiveStash.Adapters.ETSTest do
       ETS.stash(updated_socket)
 
       assert {:ok, saved_state} = StateFinder.get_from_cluster(ets_id, Node.self())
-      assert saved_state == %{username: "tester-2"}
+      assert saved_state == %{root: %{username: "tester-2"}, components: %{}}
     end
 
     test "stashes only the intersection of configured keys and present socket assigns", %{
@@ -173,7 +175,7 @@ defmodule LiveStash.Adapters.ETSTest do
 
       assert {:ok, saved_state} = StateFinder.get_from_cluster(ets_id, Node.self())
 
-      assert saved_state == %{username: "tester"}
+      assert saved_state == %{root: %{username: "tester"}, components: %{}}
     end
 
     test "crashes the process if attempting to stash to a record owned by a different PID", %{
@@ -200,7 +202,7 @@ defmodule LiveStash.Adapters.ETSTest do
     } do
       socket = put_in(socket.private.live_stash_context.reconnected?, true)
 
-      state_to_recover = %{player_level: 42, theme: "dark"}
+      state_to_recover = %{root: %{player_level: 42, theme: "dark"}, components: %{}}
 
       State.insert!(State.new(ets_id, state_to_recover, ttl: 86_400))
 
@@ -221,14 +223,14 @@ defmodule LiveStash.Adapters.ETSTest do
       opts = [ttl: 86_400]
 
       Task.async(fn ->
-        State.put!(ets_id, %{player_level: 10}, opts)
+        State.put!(ets_id, %{root: %{player_level: 10}, components: %{}}, opts)
       end)
       |> Task.await()
 
       assert {:recovered, recovered_socket} = ETS.recover_state(socket)
       assert recovered_socket.assigns.player_level == 10
 
-      assert State.put!(ets_id, %{player_level: 11}, opts) == :ok
+      assert State.put!(ets_id, %{root: %{player_level: 11}, components: %{}}, opts) == :ok
     end
 
     test "returns :not_found when there is no state in ETS for the given id", %{socket: socket} do

--- a/test/live_stash/component_test.exs
+++ b/test/live_stash/component_test.exs
@@ -1,0 +1,323 @@
+defmodule LiveStash.ComponentTest do
+  use ExUnit.Case, async: false
+
+  alias LiveStash.Component
+  alias LiveStash.Fakes
+
+  defmodule BareComponent do
+    use LiveStash.Component, stored_keys: [:count, :name]
+  end
+
+  defmodule ComponentWithMountStashed do
+    use LiveStash.Component, stored_keys: [:count]
+
+    def mount_stashed(socket) do
+      Phoenix.Component.assign(socket, :mount_stashed_calls, [
+        socket.private[:live_stash_recovered?] | socket.assigns[:mount_stashed_calls] || []
+      ])
+    end
+  end
+
+  setup do
+    Process.delete(:live_stash_components)
+    :ok
+  end
+
+  defp component_socket(assigns, private \\ %{}) do
+    socket = Fakes.socket(assigns: assigns, private: private)
+    %{socket | root_pid: self()}
+  end
+
+  describe "__before_update__/4 — first call, no recovered state" do
+    test "sets :live_stash_recovered? to false" do
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      result =
+        Component.__before_update__(socket, %{id: "a"}, [stored_keys: [:count]], BareComponent)
+
+      assert result.private[:live_stash_recovered?] == false
+    end
+
+    test "stores module and opts in socket.private for later stash/1 use" do
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+      opts = [stored_keys: [:count]]
+
+      result = Component.__before_update__(socket, %{id: "a"}, opts, BareComponent)
+
+      assert result.private[:live_stash_component_module] == BareComponent
+      assert result.private[:live_stash_component_opts] == opts
+    end
+
+    test "does not modify assigns when nothing was recovered" do
+      socket = component_socket(%{__changed__: %{}, id: "a", count: 7})
+
+      result =
+        Component.__before_update__(socket, %{id: "a"}, [stored_keys: [:count]], BareComponent)
+
+      assert result.assigns.count == 7
+    end
+  end
+
+  describe "__before_update__/4 — first call, recovered state present" do
+    test "merges recovered assigns into the socket and sets flag true" do
+      Process.put(:live_stash_components, %{
+        {BareComponent, "a"} => %{count: 42, name: "alice"}
+      })
+
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      result =
+        Component.__before_update__(
+          socket,
+          %{id: "a"},
+          [stored_keys: [:count, :name]],
+          BareComponent
+        )
+
+      assert result.assigns.count == 42
+      assert result.assigns.name == "alice"
+      assert result.private[:live_stash_recovered?] == true
+    end
+
+    test "removes the consumed entry from the process dictionary" do
+      Process.put(:live_stash_components, %{
+        {BareComponent, "a"} => %{count: 1},
+        {BareComponent, "b"} => %{count: 2}
+      })
+
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      Component.__before_update__(
+        socket,
+        %{id: "a"},
+        [stored_keys: [:count]],
+        BareComponent
+      )
+
+      remaining = Process.get(:live_stash_components)
+      assert remaining == %{{BareComponent, "b"} => %{count: 2}}
+    end
+
+    test "treats different (module, id) pairs as independent slices" do
+      Process.put(:live_stash_components, %{
+        {BareComponent, "a"} => %{count: 1},
+        {ComponentWithMountStashed, "a"} => %{count: 99}
+      })
+
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      result =
+        Component.__before_update__(
+          socket,
+          %{id: "a"},
+          [stored_keys: [:count]],
+          BareComponent
+        )
+
+      assert result.assigns.count == 1
+
+      assert Process.get(:live_stash_components) == %{
+               {ComponentWithMountStashed, "a"} => %{count: 99}
+             }
+    end
+  end
+
+  describe "__before_update__/4 — subsequent calls" do
+    test "is idempotent once :live_stash_recovered? is set (true)" do
+      socket =
+        component_socket(
+          %{__changed__: %{}, id: "a", count: 5},
+          %{live_stash_recovered?: true}
+        )
+
+      Process.put(:live_stash_components, %{{BareComponent, "a"} => %{count: 999}})
+
+      result =
+        Component.__before_update__(socket, %{id: "a"}, [stored_keys: [:count]], BareComponent)
+
+      assert result.assigns.count == 5
+      assert Process.get(:live_stash_components) == %{{BareComponent, "a"} => %{count: 999}}
+    end
+
+    test "is idempotent once :live_stash_recovered? is set (false)" do
+      socket =
+        component_socket(
+          %{__changed__: %{}, id: "a", count: 5},
+          %{live_stash_recovered?: false}
+        )
+
+      Process.put(:live_stash_components, %{{BareComponent, "a"} => %{count: 999}})
+
+      result =
+        Component.__before_update__(socket, %{id: "a"}, [stored_keys: [:count]], BareComponent)
+
+      assert result.assigns.count == 5
+      assert Process.get(:live_stash_components) == %{{BareComponent, "a"} => %{count: 999}}
+    end
+  end
+
+  describe "__before_update__/4 — mount_stashed callback" do
+    test "is called on first invocation when defined" do
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      result =
+        Component.__before_update__(
+          socket,
+          %{id: "a"},
+          [stored_keys: [:count]],
+          ComponentWithMountStashed
+        )
+
+      assert result.assigns.mount_stashed_calls == [false]
+    end
+
+    test "sees :live_stash_recovered? = true when state was recovered" do
+      Process.put(:live_stash_components, %{{ComponentWithMountStashed, "a"} => %{count: 1}})
+
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      result =
+        Component.__before_update__(
+          socket,
+          %{id: "a"},
+          [stored_keys: [:count]],
+          ComponentWithMountStashed
+        )
+
+      assert result.assigns.mount_stashed_calls == [true]
+    end
+
+    test "is not called on subsequent invocations" do
+      socket =
+        component_socket(
+          %{__changed__: %{}, id: "a", mount_stashed_calls: [false]},
+          %{live_stash_recovered?: false}
+        )
+
+      result =
+        Component.__before_update__(
+          socket,
+          %{id: "a"},
+          [stored_keys: [:count]],
+          ComponentWithMountStashed
+        )
+
+      assert result.assigns.mount_stashed_calls == [false]
+    end
+
+    test "is skipped silently when not defined on the module" do
+      socket = component_socket(%{__changed__: %{}, id: "a"})
+
+      result =
+        Component.__before_update__(socket, %{id: "a"}, [stored_keys: [:count]], BareComponent)
+
+      assert result.private[:live_stash_recovered?] == false
+    end
+  end
+
+  describe "__before_update__/4 — invalid input" do
+    test "raises a clear ArgumentError when assigns is missing :id" do
+      socket = component_socket(%{__changed__: %{}})
+
+      assert_raise ArgumentError, ~r/requires an `id` assign/, fn ->
+        Component.__before_update__(socket, %{}, [stored_keys: [:count]], BareComponent)
+      end
+    end
+
+    test "raises when :id is not a binary or integer" do
+      socket = component_socket(%{__changed__: %{}, id: %{}})
+
+      assert_raise ArgumentError, ~r/requires an `id` assign/, fn ->
+        Component.__before_update__(socket, %{id: %{}}, [stored_keys: [:count]], BareComponent)
+      end
+    end
+  end
+
+  describe "stash/1" do
+    test "sends {:live_stash_component_stash, key, assigns_to_stash} to root_pid" do
+      socket =
+        component_socket(
+          %{__changed__: %{}, id: "a", count: 7, name: "alice", extra: :ignored},
+          %{
+            live_stash_recovered?: false,
+            live_stash_component_module: BareComponent,
+            live_stash_component_opts: [stored_keys: [:count, :name]]
+          }
+        )
+
+      Component.stash(socket)
+
+      assert_receive {:live_stash_component_stash, {BareComponent, "a"},
+                      %{count: 7, name: "alice"}}
+    end
+
+    test "filters assigns_to_stash by stored_keys (drops untracked keys)" do
+      socket =
+        component_socket(
+          %{__changed__: %{}, id: "a", count: 1, ephemeral: :nope},
+          %{
+            live_stash_recovered?: false,
+            live_stash_component_module: BareComponent,
+            live_stash_component_opts: [stored_keys: [:count]]
+          }
+        )
+
+      Component.stash(socket)
+
+      assert_receive {:live_stash_component_stash, {BareComponent, "a"}, payload}
+      assert payload == %{count: 1}
+    end
+
+    test "returns the socket unchanged" do
+      socket =
+        component_socket(
+          %{__changed__: %{}, id: "a", count: 1},
+          %{
+            live_stash_recovered?: false,
+            live_stash_component_module: BareComponent,
+            live_stash_component_opts: [stored_keys: [:count]]
+          }
+        )
+
+      assert Component.stash(socket) == socket
+    end
+
+    test "raises when called before __before_update__ has populated context" do
+      socket = component_socket(%{__changed__: %{}, id: "a", count: 1})
+
+      assert_raise ArgumentError, ~r/Missing private key/, fn ->
+        Component.stash(socket)
+      end
+    end
+  end
+
+  describe "macro-generated update/2" do
+    test "wraps __before_update__ and merges parent assigns into socket" do
+      socket = component_socket(%{__changed__: %{}})
+
+      assert {:ok, result} = BareComponent.update(%{id: "a", count: 3, name: "x"}, socket)
+
+      assert result.assigns.id == "a"
+      assert result.assigns.count == 3
+      assert result.assigns.name == "x"
+      assert result.private[:live_stash_recovered?] == false
+    end
+
+    test "second invocation does not re-trigger recovery" do
+      Process.put(:live_stash_components, %{{BareComponent, "a"} => %{count: 999}})
+
+      socket = component_socket(%{__changed__: %{}})
+
+      {:ok, after_first} = BareComponent.update(%{id: "a", count: 1}, socket)
+
+      assert Process.get(:live_stash_components) == %{}
+      assert after_first.assigns.count == 1
+
+      Process.put(:live_stash_components, %{{BareComponent, "a"} => %{count: 555}})
+      {:ok, after_second} = BareComponent.update(%{id: "a", count: 2}, after_first)
+
+      assert after_second.assigns.count == 2
+      assert Process.get(:live_stash_components) == %{{BareComponent, "a"} => %{count: 555}}
+    end
+  end
+end

--- a/test/live_stash/live_stash_test.exs
+++ b/test/live_stash/live_stash_test.exs
@@ -1,0 +1,54 @@
+defmodule LiveStashTest do
+  use ExUnit.Case, async: false
+
+  alias LiveStash.Fakes
+
+  setup do
+    Process.delete(:live_stash_components)
+    :ok
+  end
+
+  describe "put_recovered_components/1" do
+    test "writes the components map to the :live_stash_components process key" do
+      assert Process.get(:live_stash_components) == nil
+
+      assert :ok = LiveStash.put_recovered_components(%{{Foo, "a"} => %{count: 1}})
+
+      assert Process.get(:live_stash_components) == %{{Foo, "a"} => %{count: 1}}
+    end
+
+    test "overwrites any previous value" do
+      LiveStash.put_recovered_components(%{{Foo, "a"} => %{count: 1}})
+      LiveStash.put_recovered_components(%{{Bar, "b"} => %{count: 2}})
+
+      assert Process.get(:live_stash_components) == %{{Bar, "b"} => %{count: 2}}
+    end
+
+    test "accepts an empty map" do
+      LiveStash.put_recovered_components(%{})
+
+      assert Process.get(:live_stash_components) == %{}
+    end
+  end
+
+  describe "get_components_buffer/1" do
+    test "returns %{} when the buffer key is missing from socket.private" do
+      socket = Fakes.socket(private: %{})
+
+      assert LiveStash.get_components_buffer(socket) == %{}
+    end
+
+    test "returns the buffer when set in socket.private" do
+      buffer = %{{Counter, "x"} => %{count: 5}}
+      socket = Fakes.socket(private: %{live_stash_components_buffer: buffer})
+
+      assert LiveStash.get_components_buffer(socket) == buffer
+    end
+
+    test "returns %{} when buffer is explicitly nil" do
+      socket = Fakes.socket(private: %{live_stash_components_buffer: nil})
+
+      assert LiveStash.get_components_buffer(socket) == %{}
+    end
+  end
+end


### PR DESCRIPTION
WORK IN PROGRESS

LiveComponents can now stash their state:
- `use LiveStash.Component, stored_keys: []` macro
- components use ids passed in `<.live_component>` to create {module, id} stash key
- macro implements `update/2`, user has to call `super()` if they decide to override it
- to handle post recovery user can check flag in every update(every here is a significant disadvantage) or implement mount_stashed function which is called after state recovery
1. root LiveView saves recovered state to process dictionary
2. component pops its state and sets flag to true, so nothing happens after first update
3. during `stash()`, component sends tracked assigns to root LV, root handles this with hook
4. state-to-be-stashed of all components is kept in socket.private of root LV and is used for diffing and to update the stash as one blob, we don't want to go back to previous key-value replacements

TO DO:
- add live_components flag to root