### PR TITLE
Bug: fix mnesia boot up

### DIFF
--- a/examples/showcase_app/config/runtime.exs
+++ b/examples/showcase_app/config/runtime.exs
@@ -21,7 +21,7 @@ if System.get_env("PHX_SERVER") do
 end
 
 config :showcase_app, ShowcaseAppWeb.Endpoint,
-  http: [port: String.to_integer(System.get_env("PORT", "4000"))]
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT", "4000"))]
 
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.

--- a/examples/showcase_app/docker-compose.yml
+++ b/examples/showcase_app/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     command: sh -c "mix deps.get && epmd -daemon && elixir --sname a@node_a --cookie livestashexamplecluster -S mix phx.server"
     environment:
       - PORT=4000
+      - MIX_ENV=test
       - LIVE_STASH_REDIS_URL=redis://redis:6379
     ports:
       - "4002:4000"
@@ -36,6 +37,7 @@ services:
     command: sh -c "mix deps.get && epmd -daemon && elixir --sname b@node_b --cookie livestashexamplecluster -S mix phx.server"
     environment:
       - PORT=4000
+      - MIX_ENV=test
       - LIVE_STASH_REDIS_URL=redis://redis:6379
     ports:
       - "4001:4000"

--- a/examples/showcase_app/e2e/helpers.js
+++ b/examples/showcase_app/e2e/helpers.js
@@ -15,9 +15,8 @@ async function waitForConnected(page) {
 }
 
 async function reconnect(page, { delayMs = 0 } = {}) {
-  await page.evaluate(() => window.liveSocket.disconnect());
-  await page.waitForFunction(
-    () => window.liveSocket && !window.liveSocket.isConnected(),
+  await page.evaluate(
+    () => new Promise((resolve) => window.liveSocket.disconnect(resolve)),
   );
 
   if (delayMs > 0) await page.waitForTimeout(delayMs);

--- a/examples/showcase_app/e2e/mnesia_split_brain.spec.js
+++ b/examples/showcase_app/e2e/mnesia_split_brain.spec.js
@@ -50,7 +50,21 @@ test.describe("Mnesia adapter - split-brain auto-heal", () => {
       )
       .toBe(true);
 
-    const baselineSize = (await nodeInfo(request, NODE_A)).table_size;
+    const poisonRes = await request.post(`${NODE_B}/test/mnesia/poison`);
+    expect(poisonRes.ok()).toBeTruthy();
+
+    await expect
+      .poll(
+        async () => {
+          const [a, b] = await Promise.all([
+            nodeInfo(request, NODE_A),
+            nodeInfo(request, NODE_B),
+          ]);
+          return b.table_size > a.table_size;
+        },
+        { timeout: 5_000, intervals: [200, 500] },
+      )
+      .toBe(true);
 
     const trigger = await request.post(
       `${NODE_B}/test/mnesia/simulate-inconsistency`,
@@ -61,15 +75,15 @@ test.describe("Mnesia adapter - split-brain auto-heal", () => {
     await expect
       .poll(
         async () => {
-          const b = await nodeInfo(request, NODE_B);
-          return b.table_size === baselineSize;
+          const [a, b] = await Promise.all([
+            nodeInfo(request, NODE_A),
+            nodeInfo(request, NODE_B),
+          ]);
+          return a.table_size === b.table_size;
         },
-        { timeout: 30_000, intervals: [500, 1_000] },
+        { timeout: 10_000, intervals: [200, 500] },
       )
       .toBe(true);
-
-    const finalA = await nodeInfo(request, NODE_A);
-    expect(finalA.table_size).toBe(baselineSize);
 
     await page.evaluate(() => window.liveSocket.disconnect());
     await page.waitForFunction(
@@ -92,7 +106,7 @@ test.describe("Mnesia adapter - split-brain auto-heal", () => {
             nodeInfo(request, NODE_A),
             nodeInfo(request, NODE_B),
           ]);
-          return a.table_size === b.table_size && a.table_size >= baselineSize;
+          return a.table_size === b.table_size;
         },
         { timeout: 5_000, intervals: [200, 500] },
       )

--- a/examples/showcase_app/lib/showcase_app_web/controllers/e2e_test/mnesia_cluster_controller.ex
+++ b/examples/showcase_app/lib/showcase_app_web/controllers/e2e_test/mnesia_cluster_controller.ex
@@ -17,6 +17,15 @@ defmodule ShowcaseAppWeb.E2eTest.MnesiaClusterController do
     })
   end
 
+  def poison(conn, _params) do
+    poison_id = "poison_pill_#{System.unique_integer([:positive])}"
+    poison_record = {@table, poison_id, self(), System.os_time(:second) + 3600, %{}}
+
+    :ets.insert(@table, poison_record)
+
+    json(conn, %{ok: true, injected_id: poison_id})
+  end
+
   def simulate_inconsistency(conn, %{"from" => remote}) when remote in @valid_remotes do
     remote_atom = String.to_existing_atom(remote)
 

--- a/examples/showcase_app/lib/showcase_app_web/router.ex
+++ b/examples/showcase_app/lib/showcase_app_web/router.ex
@@ -42,6 +42,7 @@ defmodule ShowcaseAppWeb.Router do
 
     get "/info", MnesiaClusterController, :info
     post "/simulate-inconsistency", MnesiaClusterController, :simulate_inconsistency
+    post "/poison", MnesiaClusterController, :poison
   end
 
   # Other scopes may use custom stacks.

--- a/lib/live_stash/adapters/mnesia/hook.ex
+++ b/lib/live_stash/adapters/mnesia/hook.ex
@@ -3,6 +3,7 @@ defmodule LiveStash.Adapters.Mnesia.Hook do
 
   alias LiveStash.Adapters.Mnesia.{Helpers, State}
   alias Phoenix.LiveView
+  alias LiveStash.Utils
 
   require Logger
 
@@ -26,7 +27,13 @@ defmodule LiveStash.Adapters.Mnesia.Hook do
     ttl = context.ttl
     id = Helpers.mnesia_id(context.id, context.secret)
 
-    State.bump_delete_at!(id, ttl)
+    try do
+      State.bump_delete_at!(id, ttl)
+    rescue
+      _ ->
+        msg = Utils.reason_message("Failed to bump TTL for Mnesia stash with id #{id}", :error)
+        Logger.error(msg)
+    end
 
     send_keep_alive(ttl)
 

--- a/lib/live_stash/adapters/mnesia/mnesia.ex
+++ b/lib/live_stash/adapters/mnesia/mnesia.ex
@@ -56,9 +56,8 @@ defmodule LiveStash.Adapters.Mnesia do
 
   @impl true
   def init_stash(socket, session, opts) do
-    context = Context.new(socket, session, opts)
-
-    socket = Phoenix.LiveView.put_private(socket, :live_stash_context, context)
+    socket = Common.init_context(socket, session, opts, __MODULE__)
+    context = socket.private.live_stash_context
 
     socket =
       if context.reconnected? do

--- a/lib/live_stash/adapters/mnesia/mnesia.ex
+++ b/lib/live_stash/adapters/mnesia/mnesia.ex
@@ -46,6 +46,7 @@ defmodule LiveStash.Adapters.Mnesia do
   @doc false
   def start_link(opts \\ []) do
     children = [
+      {Task.Supervisor, name: LiveStash.Adapters.Mnesia.TaskSupervisor},
       {LiveStash.Adapters.Mnesia.Storage, opts},
       {LiveStash.Adapters.Mnesia.Cleaner, opts}
     ]

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -168,6 +168,70 @@ defmodule LiveStash.Adapters.Mnesia.State do
     end
   end
 
+  @doc """
+  Re-syncs this node's table from `remote_node` after an `:inconsistent_database`
+  event, where `remote_node` is the peer the caller already decided to yield to.
+
+  The repair mechanism depends on the cause, which we tell apart by comparing the
+  table cookie with `remote_node`:
+
+    * same cookie (same-table partition) — drop the local replica and
+      re-pull it, discarding this node's divergent data;
+    * different cookie (tables created independently before connecting) — reset
+      and copy `remote_node`'s table.
+  """
+  @spec resync_from!(node()) :: :ok
+  def resync_from!(remote_node) do
+    if same_cookie?(remote_node) do
+      resync_local!()
+    else
+      adopt_from_master!(remote_node)
+    end
+  end
+
+  defp same_cookie?(remote_node) do
+    case {local_cookie(), remote_cookie(remote_node)} do
+      {nil, _} -> false
+      {_, nil} -> false
+      {cookie, cookie} -> true
+      _ -> false
+    end
+  end
+
+  defp local_cookie() do
+    :mnesia.table_info(__MODULE__, :cookie)
+  rescue
+    _ -> nil
+  end
+
+  defp remote_cookie(node) do
+    :erpc.call(node, :mnesia, :table_info, [__MODULE__, :cookie], 5_000)
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
+
+  defp resync_local!() do
+    drop_local_copy!()
+    ensure_local_copy!()
+    wait_for_table!()
+  end
+
+  defp drop_local_copy!() do
+    case Memento.Table.delete_copy(__MODULE__, node()) do
+      :ok ->
+        :ok
+
+      {:error, {:no_exists, _}} ->
+        :ok
+
+      {:error, reason} ->
+        raise RuntimeError,
+              Utils.reason_message("Failed to drop local Mnesia copy during heal", reason)
+    end
+  end
+
   defp warn_unmerged([]), do: :ok
 
   defp warn_unmerged(peers) do

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -46,66 +46,107 @@ defmodule LiveStash.Adapters.Mnesia.State do
   end
 
   @doc """
-  Sets up the Mnesia table for storing LiveView states.
-  If other nodes are already running, it creates a copy of the table on this node.
-  Otherwise, it creates the table on this node as the first node in the cluster.
+  Sets up the Mnesia table for storing LiveView states using whichever peers are
+  currently connected.
   """
   @spec setup_cluster_state!() :: :ok
-  def setup_cluster_state!() do
-    ensure_table_created!()
+  def setup_cluster_state!(), do: ensure_cluster_table!(Node.list())
+
+  @doc """
+  Ensures the `State` table exists and is replicated to this node, independent of
+  cluster boot order.
+
+  Safe to call repeatedly: it joins any reachable peers
+  into a shared schema, creates the table if no node has it yet, and ensures a
+  local `ram_copies` replica. Concurrent calls from multiple nodes are tolerated
+  because the underlying Mnesia schema operations are serialized cluster-wide and
+  "already exists" results are treated as success.
+  """
+  @spec ensure_cluster_table!([node()]) :: :ok
+  def ensure_cluster_table!(peers) do
+    join_peers!(peers)
+    ensure_table!()
+    ensure_local_copy!()
     wait_for_table!()
   end
 
-  defp ensure_table_created!() do
-    Node.list()
-    |> init_table()
-    |> handle_create_result!()
-  end
+  @join_retries 5
+  @join_retry_delay_ms 300
 
-  defp init_table([]) do
-    Memento.Table.create(__MODULE__, ram_copies: [node()])
-  end
+  defp join_peers!([]), do: :ok
+  defp join_peers!(peers), do: join_peers!(peers, @join_retries)
 
-  defp init_table(nodes) do
-    case Memento.add_nodes(nodes) do
-      {:ok, []} ->
-        Logger.warning(
-          Utils.reason_message(
-            "Could not reach any Mnesia peer",
-            {:requested_nodes, nodes}
-          )
-        )
-
-        Memento.Table.create_copy(__MODULE__, node(), :ram_copies)
-
-      {:ok, connected} ->
-        missing = nodes -- connected
-
-        if missing != [] do
-          Logger.warning(
-            Utils.message(
-              "Mnesia joined #{inspect(connected)} of requested peers. Could not reach #{inspect(missing)}"
-            )
-          )
-        end
-
-        Memento.Table.create_copy(__MODULE__, node(), :ram_copies)
+  defp join_peers!(peers, attempts_left) do
+    case Memento.add_nodes(peers) do
+      {:ok, _added} ->
+        peers
+        |> Enum.reject(&(&1 in :mnesia.system_info(:db_nodes)))
+        |> handle_unmerged(attempts_left)
 
       {:error, reason} ->
-        {:error, {:add_nodes_failed, reason}}
+        raise RuntimeError, Utils.reason_message("Failed to join Mnesia cluster", reason)
     end
   end
 
-  defp handle_create_result!(:ok), do: :ok
-  defp handle_create_result!({:error, {:already_exists, _}}), do: :ok
-  defp handle_create_result!({:error, {:already_exists, _, _}}), do: :ok
+  defp handle_unmerged([], _attempts_left), do: :ok
 
-  defp handle_create_result!({:error, {:add_nodes_failed, reason}}) do
-    raise RuntimeError, Utils.reason_message("Failed to join Mnesia cluster", reason)
+  # Retry every still-unmerged peer: Erlang distribution connects at VM start, so
+  # a `:nodeup` can fire before the peer's Mnesia has even started. We can't tell
+  # "not a Mnesia node" from "Mnesia not up yet" at a single instant, so we keep
+  # retrying.
+  defp handle_unmerged(unmerged, attempts_left) when attempts_left > 0 do
+    Process.sleep(@join_retry_delay_ms)
+    join_peers!(unmerged, attempts_left - 1)
   end
 
-  defp handle_create_result!({:error, reason}) do
-    raise RuntimeError, Utils.reason_message("Failed to set up Mnesia table", reason)
+  defp handle_unmerged(unmerged, _attempts_left) do
+    {running, non_mnesia} = Enum.split_with(unmerged, &mnesia_running?/1)
+    warn_unmerged(running)
+    log_non_mnesia(non_mnesia)
+    :ok
+  end
+
+  defp warn_unmerged([]), do: :ok
+
+  defp warn_unmerged(peers) do
+    Logger.warning(
+      Utils.reason_message(
+        "Mnesia peers are running Mnesia but did not merge into the cluster",
+        {:unmerged, peers}
+      )
+    )
+  end
+
+  defp log_non_mnesia([]), do: :ok
+
+  defp log_non_mnesia(nodes) do
+    Logger.debug(
+      Utils.reason_message("Ignoring connected nodes not running Mnesia", {:no_mnesia, nodes})
+    )
+  end
+
+  defp mnesia_running?(node) do
+    :rpc.call(node, :mnesia, :system_info, [:is_running], 2_000) == :yes
+  end
+
+  defp ensure_table!() do
+    __MODULE__
+    |> Memento.Table.create(ram_copies: [node()])
+    |> accept_already_exists!("Failed to set up Mnesia table")
+  end
+
+  defp ensure_local_copy!() do
+    __MODULE__
+    |> Memento.Table.create_copy(node(), :ram_copies)
+    |> accept_already_exists!("Failed to create local Mnesia copy")
+  end
+
+  defp accept_already_exists!(:ok, _context), do: :ok
+  defp accept_already_exists!({:error, {:already_exists, _}}, _context), do: :ok
+  defp accept_already_exists!({:error, {:already_exists, _, _}}, _context), do: :ok
+
+  defp accept_already_exists!({:error, reason}, context) do
+    raise RuntimeError, Utils.reason_message(context, reason)
   end
 
   defp wait_for_table!() do

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -171,35 +171,9 @@ defmodule LiveStash.Adapters.Mnesia.State do
   @doc """
   Re-syncs this node's table from `remote_node` after an `:inconsistent_database`
   event, where `remote_node` is the peer the caller already decided to yield to.
-
-  The repair mechanism depends on the cause, which we tell apart by whether
-  `remote_node` already shares this node's Mnesia schema:
-
-    * shared schema (same-table partition) — drop the local replica and re-pull
-      it, discarding this node's divergent data;
-    * separate schema (tables created independently before connecting) — reset
-      and copy `remote_node`'s table.
-
-  We key off local `db_nodes` membership rather than comparing cookies over the
-  network on purpose: an `:erpc` cookie probe that times out under load would
-  return `nil` and be read as "different", sending a node that actually shares
-  the table into the `delete_table` branch — which is cluster-wide and would
-  wipe `State` on every node. `db_nodes` is a local, infallible read.
   """
   @spec resync_from!(node()) :: :ok
-  def resync_from!(remote_node) do
-    if shares_schema?(remote_node) do
-      resync_local!()
-    else
-      adopt_from_master!(remote_node)
-    end
-  end
-
-  defp shares_schema?(remote_node) do
-    remote_node in :mnesia.system_info(:db_nodes)
-  end
-
-  defp resync_local!() do
+  def resync_from!(_remote_node) do
     drop_local_copy!()
     ensure_local_copy!()
     wait_for_table!()

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -56,10 +56,15 @@ defmodule LiveStash.Adapters.Mnesia.State do
   """
   @spec ensure_cluster_table!([node()]) :: :ok
   def ensure_cluster_table!(peers \\ Node.list()) do
-    join_peers!(peers)
-    ensure_table!()
-    ensure_local_copy!()
-    wait_for_table!()
+    case join_peers!(peers) do
+      :ok ->
+        ensure_table!()
+        ensure_local_copy!()
+        wait_for_table!()
+
+      {:conflict, reason} ->
+        resolve_schema_conflict!(peers, reason)
+    end
   end
 
   @join_retries 5
@@ -74,6 +79,9 @@ defmodule LiveStash.Adapters.Mnesia.State do
         peers
         |> Enum.reject(&(&1 in :mnesia.system_info(:db_nodes)))
         |> handle_unmerged(attempts_left)
+
+      {:error, {:merge_schema_failed, _} = reason} ->
+        {:conflict, reason}
 
       {:error, reason} ->
         raise RuntimeError, Utils.reason_message("Failed to join Mnesia cluster", reason)
@@ -96,6 +104,68 @@ defmodule LiveStash.Adapters.Mnesia.State do
     warn_unmerged(running)
     log_non_mnesia(non_mnesia)
     :ok
+  end
+
+  defp resolve_schema_conflict!(peers, reason) do
+    master = elect_master(peers)
+
+    if node() == master do
+      Logger.warning(
+        Utils.reason_message(
+          "Mnesia schema conflict detected; this node (#{node()}) is the master. Peers will adopt its table",
+          reason
+        )
+      )
+
+      wait_for_table!()
+    else
+      Logger.warning(
+        Utils.reason_message(
+          "Mnesia schema conflict detected; yielding to master #{master} and adopting its table",
+          reason
+        )
+      )
+
+      adopt_from_master!(master)
+    end
+  end
+
+  defp elect_master(peers) do
+    [node() | peers]
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.find(fn
+      candidate when candidate == node() -> true
+      candidate -> mnesia_running?(candidate)
+    end)
+  end
+
+  defp adopt_from_master!(master) do
+    drop_table!()
+
+    case join_peers!([master]) do
+      :ok ->
+        ensure_local_copy!()
+        wait_for_table!()
+
+      {:conflict, reason} ->
+        raise RuntimeError,
+              Utils.reason_message("Mnesia schema conflict persisted after reset", reason)
+    end
+  end
+
+  defp drop_table!() do
+    case Memento.Table.delete(__MODULE__) do
+      :ok ->
+        :ok
+
+      {:error, {:no_exists, _}} ->
+        :ok
+
+      {:error, reason} ->
+        raise RuntimeError,
+              Utils.reason_message("Failed to drop conflicting Mnesia table", reason)
+    end
   end
 
   defp warn_unmerged([]), do: :ok

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -68,7 +68,7 @@ defmodule LiveStash.Adapters.Mnesia.State do
   end
 
   @doc false
-  @spec elect_master(peers: [node()]) :: node()
+  @spec elect_master([node()]) :: node()
   def elect_master(peers) do
     [node() | peers]
     |> Enum.uniq()

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -138,17 +138,16 @@ defmodule LiveStash.Adapters.Mnesia.State do
         )
       )
 
-      adopt_from_master!(master)
+      adopt_from!(master)
     end
   end
 
-  defp adopt_from_master!(master) do
+  defp adopt_from!(master) do
     drop_table!()
 
     case join_peers!([master]) do
       :ok ->
-        ensure_local_copy!()
-        wait_for_table!()
+        copy_and_wait_from!(master)
 
       {:conflict, reason} ->
         raise RuntimeError,
@@ -181,17 +180,8 @@ defmodule LiveStash.Adapters.Mnesia.State do
   """
   @spec resync_from!(node()) :: :ok
   def resync_from!(master) do
-    :ok = :mnesia.set_master_nodes(__MODULE__, [master])
-
-    try do
-      drop_local_copy!()
-      ensure_local_copy!()
-      wait_for_table!()
-    after
-      :mnesia.set_master_nodes(__MODULE__, [])
-    end
-
-    :ok
+    drop_local_copy!()
+    copy_and_wait_from!(master)
   end
 
   defp drop_local_copy!() do
@@ -205,6 +195,17 @@ defmodule LiveStash.Adapters.Mnesia.State do
       {:error, reason} ->
         raise RuntimeError,
               Utils.reason_message("Failed to drop local Mnesia copy during heal", reason)
+    end
+  end
+
+  defp copy_and_wait_from!(master) do
+    :ok = :mnesia.set_master_nodes(__MODULE__, [master])
+
+    try do
+      ensure_local_copy!()
+      wait_for_table!()
+    after
+      :mnesia.set_master_nodes(__MODULE__, [])
     end
   end
 

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -67,6 +67,18 @@ defmodule LiveStash.Adapters.Mnesia.State do
     end
   end
 
+  @doc false
+  @spec elect_master(peers: [node()]) :: node()
+  def elect_master(peers) do
+    [node() | peers]
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.find(fn
+      candidate when candidate == node() -> true
+      candidate -> mnesia_running?(candidate)
+    end)
+  end
+
   @join_retries 5
   @join_retry_delay_ms 300
 
@@ -130,16 +142,6 @@ defmodule LiveStash.Adapters.Mnesia.State do
     end
   end
 
-  defp elect_master(peers) do
-    [node() | peers]
-    |> Enum.uniq()
-    |> Enum.sort()
-    |> Enum.find(fn
-      candidate when candidate == node() -> true
-      candidate -> mnesia_running?(candidate)
-    end)
-  end
-
   defp adopt_from_master!(master) do
     drop_table!()
 
@@ -171,12 +173,25 @@ defmodule LiveStash.Adapters.Mnesia.State do
   @doc """
   Re-syncs this node's table from `remote_node` after an `:inconsistent_database`
   event, where `remote_node` is the peer the caller already decided to yield to.
+
+  We use `:mnesia.set_master_nodes/2` to place a strict lock on Mnesia's internal
+  data loader. This guarantees that if multiple nodes are yielding simultaneously,
+  this node will not accidentally copy diverged data from another yielding peer
+  that hasn't dropped its table yet.
   """
   @spec resync_from!(node()) :: :ok
-  def resync_from!(_remote_node) do
-    drop_local_copy!()
-    ensure_local_copy!()
-    wait_for_table!()
+  def resync_from!(master) do
+    :ok = :mnesia.set_master_nodes(__MODULE__, [master])
+
+    try do
+      drop_local_copy!()
+      ensure_local_copy!()
+      wait_for_table!()
+    after
+      :mnesia.set_master_nodes(__MODULE__, [])
+    end
+
+    :ok
   end
 
   defp drop_local_copy!() do

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -1,7 +1,6 @@
 defmodule LiveStash.Adapters.Mnesia.State do
   @moduledoc """
-  A module that manages the state of LiveViews stored on the server. It uses Mnesia to store the state.
-  Mnesia replication is used, therefore the first approach is to connect to other nodes and create a copy of the table.
+  A module that manages the state of LiveViews stored on the server. It uses Mnesia to store the state with in-memory copies and replication.
 
   The state is stored in the following format:
   - id: the id of the LiveView
@@ -46,13 +45,6 @@ defmodule LiveStash.Adapters.Mnesia.State do
   end
 
   @doc """
-  Sets up the Mnesia table for storing LiveView states using whichever peers are
-  currently connected.
-  """
-  @spec setup_cluster_state!() :: :ok
-  def setup_cluster_state!(), do: ensure_cluster_table!(Node.list())
-
-  @doc """
   Ensures the `State` table exists and is replicated to this node, independent of
   cluster boot order.
 
@@ -63,7 +55,7 @@ defmodule LiveStash.Adapters.Mnesia.State do
   "already exists" results are treated as success.
   """
   @spec ensure_cluster_table!([node()]) :: :ok
-  def ensure_cluster_table!(peers) do
+  def ensure_cluster_table!(peers \\ Node.list()) do
     join_peers!(peers)
     ensure_table!()
     ensure_local_copy!()
@@ -126,7 +118,7 @@ defmodule LiveStash.Adapters.Mnesia.State do
   end
 
   defp mnesia_running?(node) do
-    :rpc.call(node, :mnesia, :system_info, [:is_running], 2_000) == :yes
+    :erpc.call(node, :mnesia, :system_info, [:is_running], 2_000) == :yes
   end
 
   defp ensure_table!() do

--- a/lib/live_stash/adapters/mnesia/state.ex
+++ b/lib/live_stash/adapters/mnesia/state.ex
@@ -172,44 +172,31 @@ defmodule LiveStash.Adapters.Mnesia.State do
   Re-syncs this node's table from `remote_node` after an `:inconsistent_database`
   event, where `remote_node` is the peer the caller already decided to yield to.
 
-  The repair mechanism depends on the cause, which we tell apart by comparing the
-  table cookie with `remote_node`:
+  The repair mechanism depends on the cause, which we tell apart by whether
+  `remote_node` already shares this node's Mnesia schema:
 
-    * same cookie (same-table partition) — drop the local replica and
-      re-pull it, discarding this node's divergent data;
-    * different cookie (tables created independently before connecting) — reset
+    * shared schema (same-table partition) — drop the local replica and re-pull
+      it, discarding this node's divergent data;
+    * separate schema (tables created independently before connecting) — reset
       and copy `remote_node`'s table.
+
+  We key off local `db_nodes` membership rather than comparing cookies over the
+  network on purpose: an `:erpc` cookie probe that times out under load would
+  return `nil` and be read as "different", sending a node that actually shares
+  the table into the `delete_table` branch — which is cluster-wide and would
+  wipe `State` on every node. `db_nodes` is a local, infallible read.
   """
   @spec resync_from!(node()) :: :ok
   def resync_from!(remote_node) do
-    if same_cookie?(remote_node) do
+    if shares_schema?(remote_node) do
       resync_local!()
     else
       adopt_from_master!(remote_node)
     end
   end
 
-  defp same_cookie?(remote_node) do
-    case {local_cookie(), remote_cookie(remote_node)} do
-      {nil, _} -> false
-      {_, nil} -> false
-      {cookie, cookie} -> true
-      _ -> false
-    end
-  end
-
-  defp local_cookie() do
-    :mnesia.table_info(__MODULE__, :cookie)
-  rescue
-    _ -> nil
-  end
-
-  defp remote_cookie(node) do
-    :erpc.call(node, :mnesia, :table_info, [__MODULE__, :cookie], 5_000)
-  rescue
-    _ -> nil
-  catch
-    _, _ -> nil
+  defp shares_schema?(remote_node) do
+    remote_node in :mnesia.system_info(:db_nodes)
   end
 
   defp resync_local!() do

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -78,9 +78,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
 
   @impl true
   def handle_info({:nodeup, node}, %{healing?: true} = state) do
-    Logger.info(
-      Utils.message("Node #{node} connected during a heal. Deferring Mnesia reconciliation.")
-    )
+    Logger.info(Utils.message("Node #{node} connected during a heal. Not reconciling."))
 
     {:noreply, state}
   end

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -114,18 +114,18 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   @impl true
-  def handle_info({ref, result}, %{reconcile_task: %Task{ref: ref}} = state) do
+  def handle_info({ref, :ok}, %{reconcile_task: %Task{ref: ref}} = state) do
     Process.demonitor(ref, [:flush])
-
-    case result do
-      :ok ->
-        Logger.info(Utils.message("Mnesia cluster reconciliation complete."))
-
-      {:error, message} ->
-        Logger.error(message)
-    end
+    Logger.info(Utils.message("Mnesia cluster reconciliation complete."))
 
     {:noreply, finish_reconcile(state)}
+  end
+
+  def handle_info({ref, other}, %{reconcile_task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    Logger.error(Utils.reason_message("Mnesia cluster reconciliation failed", other))
+
+    {:noreply, retry_reconcile(state)}
   end
 
   def handle_info(
@@ -134,7 +134,15 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       ) do
     Logger.error(Utils.reason_message("Mnesia cluster reconciliation task exited", reason))
 
-    {:noreply, finish_reconcile(state)}
+    {:noreply, retry_reconcile(state)}
+  end
+
+  def handle_info(:reconcile_retry, %{reconcile_task: %Task{}} = state) do
+    {:noreply, state}
+  end
+
+  def handle_info(:reconcile_retry, state) do
+    {:noreply, start_reconcile(state)}
   end
 
   @impl true
@@ -173,6 +181,15 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   defp finish_reconcile(state) do
+    %{state | reconcile_task: nil}
+  end
+
+  defp retry_reconcile(%{reconcile_pending?: true} = state) do
+    start_reconcile(%{state | reconcile_task: nil})
+  end
+
+  defp retry_reconcile(state) do
+    Process.send_after(self(), :reconcile_retry, @retry_delay)
     %{state | reconcile_task: nil}
   end
 

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -29,7 +29,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
     {:ok, _node} = :mnesia.subscribe(:system)
 
     :ok = :net_kernel.monitor_nodes(true)
-    State.setup_cluster_state!()
+    State.ensure_cluster_table!()
 
     auto_heal? = Application.get_env(:live_stash, :mnesia_auto_heal, true)
     {:ok, %__MODULE__{auto_heal?: auto_heal?}}

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -159,7 +159,10 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   def handle_continue({:heal, remote_node}, state) do
     case run_heal(remote_node) do
       :ok ->
-        Logger.info(Utils.message("Mnesia State table re-synced from #{remote_node} successfully."))
+        Logger.info(
+          Utils.message("Mnesia State table re-synced from #{remote_node} successfully.")
+        )
+
         {:noreply, %{state | healing?: false, retries_left: @max_retries}}
 
       {:error, reason} ->

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -47,6 +47,8 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       Utils.reason_message("Mnesia split-brain detected with #{remote_node}", :conflict)
     )
 
+    master = State.elect_master(Node.list())
+
     cond do
       not state.auto_heal? ->
         Logger.warning(
@@ -68,17 +70,15 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
 
         {:noreply, state}
 
-      node() > remote_node ->
-        Logger.info(Utils.message("Yielding state to #{remote_node}. Attempting auto-heal."))
+      node() != master ->
+        Logger.info(Utils.message("Yielding state to #{master}. Attempting auto-heal."))
 
         {:noreply, %{state | healing?: true, retries_left: @max_retries},
-         {:continue, {:heal, remote_node}}}
+         {:continue, {:heal, master}}}
 
       true ->
         Logger.info(
-          Utils.message(
-            "This node's state was selected over #{remote_node}. Node #{remote_node} is attempting auto-heal."
-          )
+          Utils.message("This node (#{node()}) is the global master. Yielding to no one.")
         )
 
         {:noreply, state}

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -8,7 +8,6 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   alias LiveStash.Adapters.Mnesia.State
   alias LiveStash.Utils
 
-  @wait_timeout 15_000
   @retry_delay 5_000
   @max_retries 3
   @task_supervisor LiveStash.Adapters.Mnesia.TaskSupervisor
@@ -72,7 +71,8 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       node() > remote_node ->
         Logger.info(Utils.message("Yielding state to #{remote_node}. Attempting auto-heal."))
 
-        {:noreply, %{state | healing?: true, retries_left: @max_retries}, {:continue, :heal}}
+        {:noreply, %{state | healing?: true, retries_left: @max_retries},
+         {:continue, {:heal, remote_node}}}
 
       true ->
         Logger.info(
@@ -86,8 +86,8 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   @impl true
-  def handle_info(:heal_retry, state) do
-    {:noreply, state, {:continue, :heal}}
+  def handle_info({:heal_retry, remote_node}, state) do
+    {:noreply, state, {:continue, {:heal, remote_node}}}
   end
 
   @impl true
@@ -156,14 +156,14 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   @impl true
-  def handle_continue(:heal, state) do
-    case run_heal() do
+  def handle_continue({:heal, remote_node}, state) do
+    case run_heal(remote_node) do
       :ok ->
-        Logger.info(Utils.message("Mnesia State table copy dropped and recreated successfully."))
+        Logger.info(Utils.message("Mnesia State table re-synced from #{remote_node} successfully."))
         {:noreply, %{state | healing?: false, retries_left: @max_retries}}
 
       {:error, reason} ->
-        schedule_retry(state, reason)
+        schedule_retry(state, remote_node, reason)
     end
   end
 
@@ -193,25 +193,16 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
     %{state | reconcile_task: nil}
   end
 
-  defp run_heal do
-    with :ok <- Memento.Table.delete_copy(State, node()),
-         :ok <- Memento.Table.create_copy(State, node(), :ram_copies) do
-      wait_for_table(State)
-    end
+  defp run_heal(remote_node) do
+    State.resync_from!(remote_node)
+    :ok
   rescue
     e ->
       Logger.error(Utils.exception_message("Mnesia auto-heal raised", e, __STACKTRACE__))
       {:error, e}
   end
 
-  defp wait_for_table(table) do
-    case Memento.Table.wait([table], @wait_timeout) do
-      {:timeout, _} -> {:error, :timeout}
-      other -> other
-    end
-  end
-
-  defp schedule_retry(%{retries_left: 1} = state, reason) do
+  defp schedule_retry(%{retries_left: 1} = state, _remote_node, reason) do
     Logger.error(
       Utils.reason_message(
         "Mnesia auto-heal exhausted all retries. Manual Mnesia restart required.",
@@ -222,7 +213,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
     {:noreply, %{state | healing?: false, retries_left: @max_retries}}
   end
 
-  defp schedule_retry(state, reason) do
+  defp schedule_retry(state, remote_node, reason) do
     Logger.warning(
       Utils.reason_message(
         "Mnesia auto-heal attempt failed. Retrying in #{div(@retry_delay, 1000)}s...",
@@ -230,7 +221,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       )
     )
 
-    Process.send_after(self(), :heal_retry, @retry_delay)
+    Process.send_after(self(), {:heal_retry, remote_node}, @retry_delay)
     {:noreply, %{state | retries_left: state.retries_left - 1}}
   end
 end

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -17,13 +17,15 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
           retries_left: non_neg_integer(),
           auto_heal?: boolean(),
           reconcile_task: Task.t() | nil,
-          reconcile_pending?: boolean()
+          reconcile_pending?: boolean(),
+          reconcile_peers: [node()]
         }
   defstruct healing?: false,
             retries_left: @max_retries,
             auto_heal?: true,
             reconcile_task: nil,
-            reconcile_pending?: false
+            reconcile_pending?: false,
+            reconcile_peers: []
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -86,8 +88,8 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   @impl true
-  def handle_info({:heal_retry, remote_node}, state) do
-    {:noreply, state, {:continue, {:heal, remote_node}}}
+  def handle_info({:heal_retry, master}, state) do
+    {:noreply, state, {:continue, {:heal, master}}}
   end
 
   @impl true
@@ -110,7 +112,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   def handle_info({:nodeup, node}, state) do
     Logger.info(Utils.message("Node #{node} connected. Reconciling Mnesia cluster membership."))
 
-    {:noreply, start_reconcile(state)}
+    {:noreply, start_reconcile(state, Node.list())}
   end
 
   @impl true
@@ -142,7 +144,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   def handle_info(:reconcile_retry, state) do
-    {:noreply, start_reconcile(state)}
+    {:noreply, start_reconcile(state, state.reconcile_peers)}
   end
 
   @impl true
@@ -156,39 +158,37 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   end
 
   @impl true
-  def handle_continue({:heal, remote_node}, state) do
-    case run_heal(remote_node) do
+  def handle_continue({:heal, master}, state) do
+    case run_heal(master) do
       :ok ->
-        Logger.info(
-          Utils.message("Mnesia State table re-synced from #{remote_node} successfully.")
-        )
+        Logger.info(Utils.message("Mnesia State table re-synced from #{master} successfully."))
 
         {:noreply, %{state | healing?: false, retries_left: @max_retries}}
 
       {:error, reason} ->
-        schedule_retry(state, remote_node, reason)
+        schedule_retry(state, master, reason)
     end
   end
 
-  defp start_reconcile(state) do
+  defp start_reconcile(state, peers) do
     task =
       Task.Supervisor.async_nolink(@task_supervisor, fn ->
-        State.ensure_cluster_table!(Node.list())
+        State.ensure_cluster_table!(peers)
       end)
 
-    %{state | reconcile_task: task, reconcile_pending?: false}
+    %{state | reconcile_task: task, reconcile_pending?: false, reconcile_peers: peers}
   end
 
   defp finish_reconcile(%{reconcile_pending?: true} = state) do
-    start_reconcile(%{state | reconcile_task: nil})
+    start_reconcile(%{state | reconcile_task: nil}, Node.list())
   end
 
   defp finish_reconcile(state) do
-    %{state | reconcile_task: nil}
+    %{state | reconcile_task: nil, reconcile_peers: []}
   end
 
   defp retry_reconcile(%{reconcile_pending?: true} = state) do
-    start_reconcile(%{state | reconcile_task: nil})
+    start_reconcile(%{state | reconcile_task: nil}, Node.list())
   end
 
   defp retry_reconcile(state) do
@@ -196,8 +196,8 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
     %{state | reconcile_task: nil}
   end
 
-  defp run_heal(remote_node) do
-    State.resync_from!(remote_node)
+  defp run_heal(master) do
+    State.resync_from!(master)
     :ok
   rescue
     e ->
@@ -205,7 +205,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       {:error, e}
   end
 
-  defp schedule_retry(%{retries_left: 1} = state, _remote_node, reason) do
+  defp schedule_retry(%{retries_left: 1} = state, _master, reason) do
     Logger.error(
       Utils.reason_message(
         "Mnesia auto-heal exhausted all retries. Manual Mnesia restart required.",
@@ -216,7 +216,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
     {:noreply, %{state | healing?: false, retries_left: @max_retries}}
   end
 
-  defp schedule_retry(state, remote_node, reason) do
+  defp schedule_retry(state, master, reason) do
     Logger.warning(
       Utils.reason_message(
         "Mnesia auto-heal attempt failed. Retrying in #{div(@retry_delay, 1000)}s...",
@@ -224,7 +224,7 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       )
     )
 
-    Process.send_after(self(), {:heal_retry, remote_node}, @retry_delay)
+    Process.send_after(self(), {:heal_retry, master}, @retry_delay)
     {:noreply, %{state | retries_left: state.retries_left - 1}}
   end
 end

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -11,13 +11,20 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   @wait_timeout 15_000
   @retry_delay 5_000
   @max_retries 3
+  @task_supervisor LiveStash.Adapters.Mnesia.TaskSupervisor
 
   @type state :: %__MODULE__{
           healing?: boolean(),
           retries_left: non_neg_integer(),
-          auto_heal?: boolean()
+          auto_heal?: boolean(),
+          reconcile_task: Task.t() | nil,
+          reconcile_pending?: boolean()
         }
-  defstruct healing?: false, retries_left: @max_retries, auto_heal?: true
+  defstruct healing?: false,
+            retries_left: @max_retries,
+            auto_heal?: true,
+            reconcile_task: nil,
+            reconcile_pending?: false
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -55,6 +62,13 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       state.healing? ->
         {:noreply, state}
 
+      state.reconcile_task != nil ->
+        Logger.info(
+          Utils.message("Mnesia cluster reconciliation in progress. Deferring split-brain heal.")
+        )
+
+        {:noreply, state}
+
       node() > remote_node ->
         Logger.info(Utils.message("Yielding state to #{remote_node}. Attempting auto-heal."))
 
@@ -83,23 +97,44 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
     {:noreply, state}
   end
 
+  def handle_info({:nodeup, node}, %{reconcile_task: %Task{}} = state) do
+    Logger.info(
+      Utils.message(
+        "Node #{node} connected while reconciling. Will re-check when the current pass finishes."
+      )
+    )
+
+    {:noreply, %{state | reconcile_pending?: true}}
+  end
+
   def handle_info({:nodeup, node}, state) do
     Logger.info(Utils.message("Node #{node} connected. Reconciling Mnesia cluster membership."))
 
-    try do
-      State.ensure_cluster_table!(Node.list())
-    rescue
-      error ->
-        Logger.error(
-          Utils.exception_message(
-            "Failed to reconcile Mnesia membership after #{node} connected",
-            error,
-            __STACKTRACE__
-          )
-        )
+    {:noreply, start_reconcile(state)}
+  end
+
+  @impl true
+  def handle_info({ref, result}, %{reconcile_task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+
+    case result do
+      :ok ->
+        Logger.info(Utils.message("Mnesia cluster reconciliation complete."))
+
+      {:error, message} ->
+        Logger.error(message)
     end
 
-    {:noreply, state}
+    {:noreply, finish_reconcile(state)}
+  end
+
+  def handle_info(
+        {:DOWN, ref, :process, _pid, reason},
+        %{reconcile_task: %Task{ref: ref}} = state
+      ) do
+    Logger.error(Utils.reason_message("Mnesia cluster reconciliation task exited", reason))
+
+    {:noreply, finish_reconcile(state)}
   end
 
   @impl true
@@ -122,6 +157,23 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
       {:error, reason} ->
         schedule_retry(state, reason)
     end
+  end
+
+  defp start_reconcile(state) do
+    task =
+      Task.Supervisor.async_nolink(@task_supervisor, fn ->
+        State.ensure_cluster_table!(Node.list())
+      end)
+
+    %{state | reconcile_task: task, reconcile_pending?: false}
+  end
+
+  defp finish_reconcile(%{reconcile_pending?: true} = state) do
+    start_reconcile(%{state | reconcile_task: nil})
+  end
+
+  defp finish_reconcile(state) do
+    %{state | reconcile_task: nil}
   end
 
   defp run_heal do

--- a/lib/live_stash/adapters/mnesia/storage.ex
+++ b/lib/live_stash/adapters/mnesia/storage.ex
@@ -27,6 +27,8 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   def init(_opts) do
     Memento.start()
     {:ok, _node} = :mnesia.subscribe(:system)
+
+    :ok = :net_kernel.monitor_nodes(true)
     State.setup_cluster_state!()
 
     auto_heal? = Application.get_env(:live_stash, :mnesia_auto_heal, true)
@@ -72,6 +74,39 @@ defmodule LiveStash.Adapters.Mnesia.Storage do
   @impl true
   def handle_info(:heal_retry, state) do
     {:noreply, state, {:continue, :heal}}
+  end
+
+  @impl true
+  def handle_info({:nodeup, node}, %{healing?: true} = state) do
+    Logger.info(
+      Utils.message("Node #{node} connected during a heal. Deferring Mnesia reconciliation.")
+    )
+
+    {:noreply, state}
+  end
+
+  def handle_info({:nodeup, node}, state) do
+    Logger.info(Utils.message("Node #{node} connected. Reconciling Mnesia cluster membership."))
+
+    try do
+      State.ensure_cluster_table!(Node.list())
+    rescue
+      error ->
+        Logger.error(
+          Utils.exception_message(
+            "Failed to reconcile Mnesia membership after #{node} connected",
+            error,
+            __STACKTRACE__
+          )
+        )
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:nodedown, _node}, state) do
+    {:noreply, state}
   end
 
   @impl true

--- a/lib/mix/tasks/e2e.ex
+++ b/lib/mix/tasks/e2e.ex
@@ -24,6 +24,8 @@ defmodule Mix.Tasks.E2e do
         IO.puts("[E2E] Booting Docker infrastructure...")
         System.cmd(docker_cmd, up_args, cd: @app_dir)
 
+        build_assets()
+
         IO.puts("[E2E] Starting Phoenix server in test environment...")
         start_phoenix_server()
 
@@ -134,6 +136,26 @@ defmodule Mix.Tasks.E2e do
 
     if status != 0 do
       Mix.raise("[E2E ERROR] Failed to install NPM dependencies. Please check the logs above.")
+    end
+  end
+
+  defp build_assets do
+    IO.puts("[E2E] Building assets (MIX_ENV=test)...")
+
+    run_mix(["assets.setup"], "install asset build tooling")
+    run_mix(["assets.build"], "build assets")
+  end
+
+  defp run_mix(args, description) do
+    {_stream, status} =
+      System.cmd("mix", args,
+        cd: @app_dir,
+        env: [{"MIX_ENV", "test"}],
+        into: IO.stream(:stdio, :line)
+      )
+
+    if status != 0 do
+      Mix.raise("[E2E ERROR] Failed to #{description} (`mix #{Enum.join(args, " ")}`).")
     end
   end
 end

--- a/test/live_stash/adapters/mnesia/cleaner_test.exs
+++ b/test/live_stash/adapters/mnesia/cleaner_test.exs
@@ -5,7 +5,7 @@ defmodule LiveStash.Adapters.Mnesia.MnesiaCleanerTest do
   alias LiveStash.Adapters.Mnesia.State
 
   setup_all do
-    State.setup_cluster_state!()
+    State.ensure_cluster_table!()
     :ok
   end
 

--- a/test/live_stash/adapters/mnesia/hook_test.exs
+++ b/test/live_stash/adapters/mnesia/hook_test.exs
@@ -5,7 +5,7 @@ defmodule LiveStash.Adapters.Mnesia.HookTest do
   alias LiveStash.Fakes
 
   setup_all do
-    State.setup_cluster_state!()
+    State.ensure_cluster_table!()
     :ok
   end
 

--- a/test/live_stash/adapters/mnesia/mnesia_test.exs
+++ b/test/live_stash/adapters/mnesia/mnesia_test.exs
@@ -9,7 +9,7 @@ defmodule LiveStash.Adapters.MnesiaTest do
   alias LiveStash.Fakes
 
   setup_all do
-    State.setup_cluster_state!()
+    State.ensure_cluster_table!()
     :ok
   end
 
@@ -80,7 +80,7 @@ defmodule LiveStash.Adapters.MnesiaTest do
       socket: socket,
       stash_id: stash_id
     } do
-      on_exit(fn -> State.setup_cluster_state!() end)
+      on_exit(fn -> State.ensure_cluster_table!() end)
 
       :mnesia.delete_table(LiveStash.Adapters.Mnesia.State)
 

--- a/test/live_stash/adapters/mnesia/state_test.exs
+++ b/test/live_stash/adapters/mnesia/state_test.exs
@@ -4,7 +4,7 @@ defmodule LiveStash.Adapters.Mnesia.StateTest do
   alias LiveStash.Adapters.Mnesia.State
 
   setup_all do
-    State.setup_cluster_state!()
+    State.ensure_cluster_table!()
     :ok
   end
 


### PR DESCRIPTION
In a scenario where Mnesia booted before cluster connected, each Node created it's own table and the conflict was never detected even by Mnesia `:inconsistent_database` event.