### PR TITLE
Bug: unify recover status in browser adapter

### DIFF
--- a/lib/live_stash/adapters/browser_memory/serializer.ex
+++ b/lib/live_stash/adapters/browser_memory/serializer.ex
@@ -18,18 +18,22 @@ defmodule LiveStash.Adapters.BrowserMemory.Serializer do
   end
 
   @spec decode_token(socket :: Socket.t(), value :: binary(), opts :: map()) ::
-          {:error, :expired | :invalid | :missing} | {:ok, term()}
+          :not_found | {:error, :invalid | :missing} | {:ok, term()}
   def decode_token(socket, value, %{security_mode: :sign} = opts) do
-    with {:ok, binary} <- Phoenix.Token.verify(socket, opts.secret, value, max_age: opts.ttl) do
-      decompress_term(binary)
-    end
+    socket
+    |> Phoenix.Token.verify(opts.secret, value, max_age: opts.ttl)
+    |> decode_verified()
   end
 
   def decode_token(socket, value, %{security_mode: :encrypt} = opts) do
-    with {:ok, binary} <- Phoenix.Token.decrypt(socket, opts.secret, value, max_age: opts.ttl) do
-      decompress_term(binary)
-    end
+    socket
+    |> Phoenix.Token.decrypt(opts.secret, value, max_age: opts.ttl)
+    |> decode_verified()
   end
+
+  defp decode_verified({:ok, binary}), do: decompress_term(binary)
+  defp decode_verified({:error, :expired}), do: :not_found
+  defp decode_verified(error), do: error
 
   defp compress_term(term) do
     :erlang.term_to_binary(term, [{:compressed, 1}])

--- a/test/live_stash/adapters/browser_memory/browser_memory_test.exs
+++ b/test/live_stash/adapters/browser_memory/browser_memory_test.exs
@@ -174,6 +174,33 @@ defmodule LiveStash.Adapters.BrowserMemoryTest do
       assert returned_socket == socket
     end
 
+    test "returns :not_found when stashed state token has expired", %{socket: socket} do
+      socket = put_in(socket.private.live_stash_context.reconnected?, true)
+      socket = put_in(socket.private.live_stash_context.ttl, 1)
+
+      settings = %{
+        ttl: 1,
+        secret: socket.private.live_stash_context.secret,
+        security_mode: :sign
+      }
+
+      stashed_state =
+        Serializer.encode_token(socket, %{version: nil, assigns: %{player_id: 999}}, settings)
+
+      Process.sleep(2000)
+
+      params = %{
+        "liveStash" => %{
+          "stashedState" => stashed_state
+        }
+      }
+
+      socket_with_params = put_in(socket.private.connect_params, params)
+
+      assert {:not_found, returned_socket} = BrowserMemory.recover_state(socket_with_params)
+      assert returned_socket == socket_with_params
+    end
+
     test "returns :error, logs warning and pushes init-browser-memory event when token decryption fails",
          %{socket: socket} do
       socket = put_in(socket.private.live_stash_context.reconnected?, true)

--- a/test/live_stash/adapters/browser_memory/serializer_test.exs
+++ b/test/live_stash/adapters/browser_memory/serializer_test.exs
@@ -61,14 +61,14 @@ defmodule LiveStash.Adapters.BrowserMemory.SerializerTest do
                Serializer.decode_token(socket, "invalid_or_malformed_token", opts)
     end
 
-    test "returns an error for expired tokens", %{socket: socket} do
+    test "returns :not_found for expired tokens", %{socket: socket} do
       opts = %{security_mode: :sign, secret: "my_secret", ttl: 1}
 
       token = Serializer.encode_token(socket, %{time_test: "data"}, opts)
 
       Process.sleep(2000)
 
-      assert {:error, :expired} = Serializer.decode_token(socket, token, opts)
+      assert :not_found = Serializer.decode_token(socket, token, opts)
     end
   end
 end


### PR DESCRIPTION
Return `:not_found` instead of `:error` for outdated stashes in browser memory adapter