### PR TITLE
Add telemetry events and runtime-configurable cleanup intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ erl_crash.dump
 
 # Node dependencies (assets)
 /assets/node_modules/
+
+.env
+.env.local

--- a/lib/live_stash.ex
+++ b/lib/live_stash.ex
@@ -162,9 +162,17 @@ defmodule LiveStash do
   """
   @spec stash(socket :: Socket.t()) :: Socket.t()
   def stash(socket) do
+    adapter = get_adapter(socket)
+    before_fp = socket.private.live_stash_context.stash_fingerprint
+    socket = apply(adapter, :stash, [socket])
+    meta = %{adapter: adapter, live_view_module: socket.view}
+    :telemetry.execute([:live_stash, :stash, :called], %{count: 1}, meta)
+
+    if socket.private.live_stash_context.stash_fingerprint != before_fp do
+      :telemetry.execute([:live_stash, :stash, :executed], %{count: 1}, meta)
+    end
+
     socket
-    |> get_adapter()
-    |> apply(:stash, [socket])
   end
 
   @doc """
@@ -189,9 +197,18 @@ defmodule LiveStash do
   """
   @spec recover_state(socket :: Socket.t()) :: {recovery_status(), Socket.t()}
   def recover_state(socket) do
-    socket
-    |> get_adapter()
-    |> apply(:recover_state, [socket])
+    adapter = get_adapter(socket)
+    {status, socket} = apply(adapter, :recover_state, [socket])
+
+    if Phoenix.LiveView.connected?(socket) do
+      :telemetry.execute(
+        [:live_stash, :recover_state],
+        %{count: 1},
+        %{adapter: adapter, live_view_module: socket.view, status: status}
+      )
+    end
+
+    {status, socket}
   end
 
   @doc """

--- a/lib/live_stash/adapters/ets/cleaner.ex
+++ b/lib/live_stash/adapters/ets/cleaner.ex
@@ -8,7 +8,6 @@ defmodule LiveStash.Adapters.ETS.Cleaner do
   alias LiveStash.Adapters.ETS.State
   alias LiveStash.Utils
 
-  @cleanup_interval Application.compile_env(:live_stash, :ets_cleanup_interval, 1 * 60 * 1_000)
   @table_name Application.compile_env(:live_stash, :ets_table_name, :live_stash_server_storage)
 
   def start_link(opts \\ []) do
@@ -57,5 +56,10 @@ defmodule LiveStash.Adapters.ETS.Cleaner do
     end
   end
 
-  defp schedule_cleanup(), do: Process.send_after(self(), :cleanup, @cleanup_interval)
+  defp schedule_cleanup(),
+    do: Process.send_after(self(), :cleanup, cleanup_interval())
+
+  defp cleanup_interval do
+    Application.get_env(:live_stash, :ets_cleanup_interval, 60_000)
+  end
 end

--- a/lib/live_stash/adapters/mnesia/cleaner.ex
+++ b/lib/live_stash/adapters/mnesia/cleaner.ex
@@ -8,8 +8,6 @@ defmodule LiveStash.Adapters.Mnesia.Cleaner do
   alias LiveStash.Adapters.Mnesia.State
   alias LiveStash.Utils
 
-  @cleanup_interval Application.compile_env(:live_stash, :mnesia_cleanup_interval, 1 * 60 * 1_000)
-
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -64,5 +62,10 @@ defmodule LiveStash.Adapters.Mnesia.Cleaner do
     _ -> false
   end
 
-  defp schedule_cleanup(), do: Process.send_after(self(), :cleanup, @cleanup_interval)
+  defp schedule_cleanup(),
+    do: Process.send_after(self(), :cleanup, cleanup_interval())
+
+  defp cleanup_interval do
+    Application.get_env(:live_stash, :mnesia_cleanup_interval, 60_000)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule LiveStash.MixProject do
     [
       {:memento, "~> 0.5.0", optional: true},
       {:phoenix_live_view, "~> 1.0"},
+      {:telemetry, "~> 1.0"},
       {:uniq, "~> 0.6"},
       {:redix, "~> 1.1", optional: true},
       {:castore, ">= 0.0.0", optional: true},


### PR DESCRIPTION
## What

Library changes extracted from the `92-add-performance-tests` branch, so they can land on `main` independently of the performance-test infrastructure.

- Emit `:live_stash` telemetry:
  - `[:live_stash, :stash, :called]` and `[:live_stash, :stash, :executed]` on `stash/1`
  - `[:live_stash, :recover_state]` (with status) on `recover_state/1` when connected
- Make ETS/Mnesia cleanup intervals runtime-configurable — `Application.get_env` instead of `compile_env`
- Add `:telemetry` as an explicit dependency (already locked transitively; `mix.lock` unchanged)
- Ignore `.env` / `.env.local`

## Excluded

Test-infra changes (`testing/` dir, `examples/showcase_app` removal, `e2e.yml`/`mix e2e` repointing) stay on the perf-tests branch — they reference the `testing/` dir which does not exist on `main`.

## Test

`mix compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)