### PR TITLE
Bug: fix ETS stashing for tuple-containing state

### DIFF
--- a/lib/live_stash/adapters/ets/state.ex
+++ b/lib/live_stash/adapters/ets/state.ex
@@ -77,7 +77,7 @@ defmodule LiveStash.Adapters.ETS.State do
     new_record = new(id, state, opts, version)
 
     match_spec = [
-      {{:state, id, pid, :_, :_, :_}, [], [{new_record}]}
+      {{:state, id, pid, :_, :_, :_}, [], [{:const, new_record}]}
     ]
 
     if :ets.select_replace(@table_name, match_spec) == 0 do

--- a/test/live_stash/adapters/ets/state_test.exs
+++ b/test/live_stash/adapters/ets/state_test.exs
@@ -65,6 +65,16 @@ defmodule LiveStash.Adapters.ETS.StateTest do
       assert state == %{key2: "new_value"}
     end
 
+    test "stores state containing tuple values" do
+      id = "tuple_state_id"
+      state = %{coordinates: {10, 20}}
+
+      assert :ok = State.put!(id, state, ttl: 1)
+
+      assert {:ok, stored_state, _version} = State.get_by_id!(id)
+      assert stored_state == state
+    end
+
     test "raises exception if state is owned by a different process (PID mismatch)" do
       id = "test_id"
       opts = [ttl: 1]

--- a/test/live_stash/adapters/ets/state_test.exs
+++ b/test/live_stash/adapters/ets/state_test.exs
@@ -65,14 +65,16 @@ defmodule LiveStash.Adapters.ETS.StateTest do
       assert state == %{key2: "new_value"}
     end
 
-    test "stores state containing tuple values" do
+    test "replaces one tuple-containing state with another" do
       id = "tuple_state_id"
-      state = %{coordinates: {10, 20}}
+      initial_state = %{coordinates: {0, 0}}
+      replacement_state = %{coordinates: {10, 20}}
 
-      assert :ok = State.put!(id, state, ttl: 1)
+      assert :ok = State.put!(id, initial_state, ttl: 1)
+      assert {:ok, ^initial_state, _} = State.get_by_id!(id)
 
-      assert {:ok, stored_state, _version} = State.get_by_id!(id)
-      assert stored_state == state
+      assert :ok = State.put!(id, replacement_state, ttl: 1)
+      assert {:ok, ^replacement_state, _} = State.get_by_id!(id)
     end
 
     test "raises exception if state is owned by a different process (PID mismatch)" do


### PR DESCRIPTION
 ## Summary

  Fix ETS stashing when the stored state contains tuples.

  `ets.select_replace/2` evaluates replacement values using match-spec syntax, where tuples may be interpreted as expressions. OTP documents `{const, term()}` as the standard way to embed a literal term in a match-spec body and uses it in the generic `select_replace/2` example.

  This change wraps the replacement record in `{:const, ...}` and adds regression coverage for tuple-containing state.

  [OTP `ets.select_replace/2` documentation](https://www.erlang.org/docs/29/apps/stdlib/ets.html#select_replace-2)

  Fixes #121

  ## Testing

  - `mix format --check-formatted`
  - `mix credo`
  - `mix compile --warnings-as-errors`
  - `mix test` - 196 tests, 0 failures